### PR TITLE
uaa.yml has login.saml.serviceProviderKeyPassword

### DIFF
--- a/uaa.yml
+++ b/uaa.yml
@@ -62,6 +62,7 @@
       login:
         saml:
           serviceProviderKey: ((uaa_service_provider_ssl.private_key))
+          serviceProviderKeyPassword: "" # TODO: Remove this when UAA defaults this value
           serviceProviderCertificate: ((uaa_service_provider_ssl.certificate))
       uaadb:
         address: 127.0.0.1


### PR DESCRIPTION
uaa-release requires an empty serviceProviderKeyPassword even if the
serviceProviderKey is not password-protected. This default allows
deployments to work until such a time as uaa-release defaults the value
itself.