### PR TITLE
Add version to cpi releases

### DIFF
--- a/aws/cpi.yml
+++ b/aws/cpi.yml
@@ -3,6 +3,7 @@
   path: /releases/-
   value:
     name: bosh-aws-cpi
+    version: 60
     url: https://bosh.io/d/github.com/cloudfoundry-incubator/bosh-aws-cpi-release?v=60
     sha1: 8e40a9ff892204007889037f094a1b0d23777058
 

--- a/azure/cpi.yml
+++ b/azure/cpi.yml
@@ -3,6 +3,7 @@
   path: /releases/-
   value:
     name: bosh-azure-cpi
+    version: 20
     url: https://bosh.io/d/github.com/cloudfoundry-incubator/bosh-azure-cpi-release?v=20
     sha1: fb0180c685714d064b5a467eb6f2b34388fadf0a
 

--- a/gcp/cpi.yml
+++ b/gcp/cpi.yml
@@ -3,6 +3,7 @@
   path: /releases/-
   value:
     name: bosh-google-cpi
+    version: 25.6.1
     url: https://bosh.io/d/github.com/cloudfoundry-incubator/bosh-google-cpi-release?v=25.6.1
     sha1: fc8c7025c3ba3aef66e005a4bdf7fd3d5e997974
 

--- a/openstack/cpi.yml
+++ b/openstack/cpi.yml
@@ -3,6 +3,7 @@
   path: /releases/-
   value:
     name: bosh-openstack-cpi
+    version: 27
     url: https://bosh.io/d/github.com/cloudfoundry-incubator/bosh-openstack-cpi-release?v=27
     sha1: 85e6244978f775c888bbd303b874a2c158eb43c4
 

--- a/virtualbox/cpi.yml
+++ b/virtualbox/cpi.yml
@@ -3,6 +3,7 @@
   path: /releases/-
   value:
     name: bosh-virtualbox-cpi
+    version: 0.0.2
     url: https://bosh.io/d/github.com/cppforlife/bosh-virtualbox-cpi-release?v=0.0.2
     sha1: 807fba203ca71bea7b686ce1301d98ee29885fcc
 


### PR DESCRIPTION
create-env doesn't care much, but deploy does.
Make it consistent with bosh.yml which also has a version for bosh.