### PR TITLE
Add custom-ca and trusted-certs

### DIFF
--- a/openstack/custom-ca.yml
+++ b/openstack/custom-ca.yml
@@ -1,0 +1,5 @@
+---
+- type: replace
+  path: /instance_groups/name=bosh/properties/openstack/connection_options?
+  value:
+    ca_cert: ((openstack_ca_cert))

--- a/openstack/trusted-certs.yml
+++ b/openstack/trusted-certs.yml
@@ -1,0 +1,5 @@
+---
+- type: replace
+  path: /instance_groups/name=bosh/properties/director/trusted_certs?
+  value:
+    ca_cert: ((openstack_ca_cert))


### PR DESCRIPTION
when you have self-signed certs for your openstack, custom-ca is necessary.
trusted-certs are only needed, if VMs deployed by bosh also need the same certs (i.e. if you deploy bosh with bosh)