### PR TITLE
Small quality-of-life improvements to variable names

### DIFF
--- a/gcp/cloud-config.yml
+++ b/gcp/cloud-config.yml
@@ -36,7 +36,7 @@ networks:
       network_name: ((network))
       subnetwork_name: ((subnetwork))
       ephemeral_external_ip: true
-      tags: [internal, no-ip]
+      tags: ((tags))
 - name: vip
   type: vip
 


### PR DESCRIPTION
Since we're (the CPI team) using terraform for our GCP and AWS deployments having more explicit variable names helps us to chain inputs/outputs from terraform to the bosh manifests that will ultimately be interpolated.