### PR TITLE
BOSH uses Google's NTP servers

### DIFF
--- a/bosh.yml
+++ b/bosh.yml
@@ -93,8 +93,10 @@ instance_groups:
         ca_cert: ((director_ssl.ca))
       resurrector_enabled: true
     ntp: &ntp
-    - 0.pool.ntp.org
-    - 1.pool.ntp.org
+    - time1.google.com
+    - time2.google.com
+    - time3.google.com
+    - time4.google.com
     agent:
       mbus: nats://nats:((nats_password))@((internal_ip)):4222
 


### PR DESCRIPTION
Google announces public NTP servers: https://cloudplatform.googleblog.com/2016/11/making-every-leap-second-count-with-our-new-public-NTP-servers.html

Google NTP servers are stratum 2, which is better than the stratum 3 & 4 servers which typically make up the NTP pool.

Don't mix google NTP servers with the pool's NTP servers; Google "smears" their leap seconds, and the pool doesn't (https://community.ntppool.org/t/leap-second-2017-status/59/11).

> but don’t mix smearing and non-smearing time servers.

Configuration notes: https://developers.google.com/time/guides