### PR TITLE
use internal_director_ip for readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ $ bosh create-env ~/workspace/bosh-deployment/bosh.yml \
   -v director_name=$(basename $PWD) \
   -v internal_cidr=10.0.0.0/24 \
   -v internal_gw=10.0.0.1 \
-  -v internal_ip=10.0.0.6 \
+  -v internal_director_ip=10.0.0.6 \
   --var-file private_key=~/Downloads/bosh.pem
 
 # Alias deployed Director


### PR DESCRIPTION
If you try to deploy using just the example provided in the manifest you get this error:
```
Deployment manifest: '/Users/pivotal/workspace/bosh-deployment/bosh.yml'
Deployment state: '/Users/pivotal/scratch/aws/director-state.json'

Started validating
Failed validating (00:00:00)

Parsing release set manifest '/Users/pivotal/workspace/bosh-deployment/bosh.yml':
  Evaluating manifest:
    - Expected to find variables:
        - internal_director_ip

Exit code 1
```

Turns out the CPI team submitted a PR to rename a bunch of `internal_ip`s to `internal_director_ip`s so here I go, fixing the issue we created. Look at what a great contributor I am.

Love,
Zak
😻😻😻😻😻😻😻😻😻😻😻😻😻😻😻😻😻😻😻😻😻😻😻😻😻😻