### PR TITLE
Fix keystone-v2 opsfile

### DIFF
--- a/openstack/keystone-v2.yml
+++ b/openstack/keystone-v2.yml
@@ -7,16 +7,15 @@
 
 - type: replace
   path: /instance_groups/name=bosh/properties/openstack/tenant?
-  value: ((tenant))
+  value: ((openstack_tenant))
 
 # Inside cloud_provider
 - type: remove
   path: /cloud_provider/properties/openstack/project
-  value: ((project))
 
 - type: remove
   path: /cloud_provider/properties/openstack/domain
-  value: ((domain))
 
 - type: replace
   path: /cloud_provider/properties/openstack/tenant?
+  value: ((openstack_tenant))

--- a/openstack/keystone-v2.yml
+++ b/openstack/keystone-v2.yml
@@ -10,13 +10,13 @@
   value: ((tenant))
 
 # Inside cloud_provider
-- type: replace
-  path: /cloud_provider/properties/openstack/project?
+- type: remove
+  path: /cloud_provider/properties/openstack/project
   value: ((project))
 
-- type: replace
-  path: /cloud_provider/properties/openstack/domain?
+- type: remove
+  path: /cloud_provider/properties/openstack/domain
   value: ((domain))
 
-- type: remove
-  path: /cloud_provider/properties/openstack/tenant
+- type: replace
+  path: /cloud_provider/properties/openstack/tenant?


### PR DESCRIPTION
* cloud_provider and openstack section should do the same thing
* prefix tenant variable with `openstack_`