### PR TITLE
Match previous BOSH-Lite settings

### DIFF
--- a/bosh-lite.yml
+++ b/bosh-lite.yml
@@ -45,6 +45,10 @@
   value: warden_cpi
 
 - type: replace
+  path: /instance_groups/name=bosh/properties/director/ignore_missing_gateway?
+  value: true
+
+- type: replace
   path: /instance_groups/name=bosh/properties/compiled_package_cache?
   value:
     provider: local

--- a/docs/bosh-lite-on-vbox.md
+++ b/docs/bosh-lite-on-vbox.md
@@ -30,7 +30,7 @@
       -o ~/workspace/bosh-deployment/bosh-lite-runc.yml \
       -o ~/workspace/bosh-deployment/jumpbox-user.yml \
       --vars-store ./creds.yml \
-      -v director_name=vbox \
+      -v director_name="Bosh Lite Director" \
       -v internal_ip=192.168.50.6 \
       -v internal_gw=192.168.50.1 \
       -v internal_cidr=192.168.50.0/24 \


### PR DESCRIPTION
- [CF manifest-generation script](https://github.com/cloudfoundry/cf-release/blob/v250/scripts/generate-bosh-lite-dev-manifest#L27) expects director name of "Bosh Lite Director".
- [Networks in legacy CF BOSH-Lite manifest template](https://github.com/cloudfoundry/cf-release/blob/v250/templates/cf-infrastructure-bosh-lite.yml#L1442-L3114) do not have gateways.

These settings correspond to the current [director name](https://github.com/cloudfoundry/bosh-lite/blob/9000.137.0/packer/templates/bosh_lite_manifest_template.yml#L69) and [gateway compatibility setting](https://github.com/cloudfoundry/bosh-lite/blob/9000.137.0/packer/templates/bosh_lite_manifest_template.yml#L82) in the manifest template in the bosh-lite repo.