### PR TITLE
Add bosh-lite on gcp opsfile to ensure sufficient resources

### DIFF
--- a/bosh-lite.yml
+++ b/bosh-lite.yml
@@ -80,3 +80,11 @@
     allow_host_access: true
     destroy_containers_on_start: true # avoids snapshots
     default_container_grace_time: 0
+
+- type: replace
+  path: /disk_pools/name=disks/disk_size
+  value: 65_536
+
+- type: replace
+  path: /instance_groups/name=bosh/properties/garden/graph_cleanup_threshold_in_mb?
+  value: 0

--- a/gcp/bosh-lite-vm-type.yml
+++ b/gcp/bosh-lite-vm-type.yml
@@ -1,17 +1,5 @@
 ---
 # Configure sizes for bosh-lite on gcp
 - type: replace
-  path: /resource_pools/name=vms/cloud_properties?
-  value:
-    zone: ((zone))
-    machine_type: n1-standard-8
-    root_disk_size_gb: 40
-    root_disk_type: pd-standard
-
-- type: replace
-  path: /disk_pools/name=disks/disk_size
-  value: 65_536
-
-- type: replace
-  path: /instance_groups/name=bosh/properties/garden/graph_cleanup_threshold_in_mb?
-  value: 0
+  path: /resource_pools/name=vms/cloud_properties/machine_type
+  value: n1-standard-8

--- a/gcp/bosh-lite-vm-type.yml
+++ b/gcp/bosh-lite-vm-type.yml
@@ -1,0 +1,17 @@
+---
+# Configure sizes for bosh-lite on gcp
+- type: replace
+  path: /resource_pools/name=vms/cloud_properties?
+  value:
+    zone: ((zone))
+    machine_type: n1-standard-8
+    root_disk_size_gb: 40
+    root_disk_type: pd-standard
+
+- type: replace
+  path: /disk_pools/name=disks/disk_size
+  value: 65_536
+
+- type: replace
+  path: /instance_groups/name=bosh/properties/garden/graph_cleanup_threshold_in_mb?
+  value: 0


### PR DESCRIPTION
After discussing with Dmitriy, we decided to move sections that are not gcp-specific to the default bosh-lite opsfile. So, here is the updated PR!

Chunyi && Jesse