### PR TITLE
Update PowerDNS to trigger bosh migrations

### DIFF
--- a/powerdns.yml
+++ b/powerdns.yml
@@ -7,15 +7,17 @@
   value:
     name: powerdns
     release: bosh
-    properties:
-      dns:
-        address: 127.0.0.1
-        db:
-          database: powerdns
-          host: 127.0.0.1
-          user: postgres
-          password: ((postgres_password))
-        recursor: ((dns_recursor_ip))
+
+- type: replace
+  path: /instance_groups/name=bosh/properties/dns?
+  value:
+    address: 127.0.0.1
+    db:
+      database: powerdns
+      host: 127.0.0.1
+      user: postgres
+      password: ((postgres_password))
+    recursor: ((dns_recursor_ip))
 
 - type: replace
   path: /networks/name=default/subnets/0/dns


### PR DESCRIPTION
BOSH will only trigger the migrations if PowerDNS properties are at the top level:
https://github.com/cloudfoundry/bosh/blob/master/src/bosh-director/bin/bosh-director-migrate#L43-L47