### PR TITLE
Remove registry.http properties

### DIFF
--- a/openstack/cpi.yml
+++ b/openstack/cpi.yml
@@ -42,7 +42,6 @@
       password: ((postgres_password))
       database: bosh
       adapter: postgres
-    http: {user: registry, password: ((registry_password)), port: 25777}
     username: registry
     password: ((registry_password))
     port: 25777


### PR DESCRIPTION
Unnecessary with bosh >=v261
OpenStack CPI doesn't even read it anymore.