### PR TITLE
Also add custom CA to cloud_provider for create-env

### DIFF
--- a/openstack/custom-ca.yml
+++ b/openstack/custom-ca.yml
@@ -3,3 +3,8 @@
   path: /instance_groups/name=bosh/properties/openstack/connection_options?
   value:
     ca_cert: ((openstack_ca_cert))
+
+- type: replace
+  path: /cloud_provider/properties/openstack/connection_options?
+  value:
+    ca_cert: ((openstack_ca_cert))


### PR DESCRIPTION
Seems like anchors get resolved in the middle of computing, so you have to do this stuff redundantly :(