### PR TITLE
Bump BOSH-Google-CPI to 25.6.2

### DIFF
--- a/gcp/cpi.yml
+++ b/gcp/cpi.yml
@@ -3,9 +3,9 @@
   path: /releases/-
   value:
     name: bosh-google-cpi
-    version: 25.6.1
-    url: https://bosh.io/d/github.com/cloudfoundry-incubator/bosh-google-cpi-release?v=25.6.1
-    sha1: fc8c7025c3ba3aef66e005a4bdf7fd3d5e997974
+    version: 25.6.2
+    url: https://bosh.io/d/github.com/cloudfoundry-incubator/bosh-google-cpi-release?v=25.6.2
+    sha1: b4865397d867655fdcc112bc5a7f9a5025cdf311
 
 - type: replace
   path: /resource_pools/name=vms/stemcell?


### PR DESCRIPTION
`BOSH-Google-CPI` needs to be at least version `25.6.2` for the bosh director to use the windows light stemcells.