### PR TITLE
Improving vsphere cpi, adding support for s3, custom dns and extra network

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.json
 creds.yml
 tmp
+iaas-config.yml

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 *.json
 creds.yml
 tmp
-iaas-config.yml

--- a/additional-net.yml
+++ b/additional-net.yml
@@ -1,14 +1,14 @@
 - type: replace
   path: /networks/-
   value:
-    name: ((secondary_net_name))
+    name: secondary
     type: manual
     subnets:
-    - range: ((secondary_net_range))
-      gateway: ((secondary_net_gateway))
-      dns: ((secondary_net_dns))
-      cloud_properties: ((secondary_net_cloud_properties))
-      static: [((secondary_net_ip))]
+    - range: ((second_net_cidr))
+      gateway: ((second_net_gw))
+      dns: ((second_net_dns))
+      cloud_properties: ((second_net_cloud_properties))
+      static: [((secondary_ip))]
 
 - type: replace
   path: /instance_groups/name=bosh/networks/0/default?
@@ -17,6 +17,5 @@
 - type: replace
   path: /instance_groups/name=bosh/networks/-
   value:
-    name: ((secondary_net_name))
-    static_ips: [((secondary_net_ip))]
-
+    name: secondary
+    static_ips: [((second_net_ip))]

--- a/additional-net.yml
+++ b/additional-net.yml
@@ -1,0 +1,22 @@
+- type: replace
+  path: /networks/-
+  value:
+    name: ((secondary_net_name))
+    type: manual
+    subnets:
+    - range: ((secondary_net_range))
+      gateway: ((secondary_net_gateway))
+      dns: ((secondary_net_dns))
+      cloud_properties: ((secondary_net_cloud_properties))
+      static: [((secondary_net_ip))]
+
+- type: replace
+  path: /instance_groups/name=bosh/networks/0/default?
+  value: [dns, gateway]
+
+- type: replace
+  path: /instance_groups/name=bosh/networks/-
+  value:
+    name: ((secondary_net_name))
+    static_ips: [((secondary_net_ip))]
+

--- a/blobstore-s3.yml
+++ b/blobstore-s3.yml
@@ -1,0 +1,15 @@
+- type: replace
+  path: /instance_groups/name=bosh/properties/blobstore
+  value:
+    access_key_id: ((s3_blobstore_access_key))
+    secret_access_key: ((s3_blobstore_secret_key))
+    s3_region: ((s3_blobstore_bucket_location))
+    bucket_name: ((s3_blobstore_bucket_name))
+    provider: s3
+    director:
+      user: director
+      password: ((blobstore_director_password))
+    agent:
+      user: agent
+      password: ((blobstore_agent_password))
+

--- a/internal_nameservers.yml
+++ b/internal_nameservers.yml
@@ -1,0 +1,4 @@
+
+- type: replace
+  path: /networks/name=default/subnets/0/dns?
+  value: ((internal_dns_servers))

--- a/test.sh
+++ b/test.sh
@@ -281,14 +281,16 @@ bosh create-env bosh.yml \
   -v internal_ip=test \
   -v network_name=test \
   -v vcenter_dc=test \
-  -v vcenter_ds=test \
+  -v vcenter_ds_ephemeral=test \
+  -v vcenter_ds_persistent=test \
   -v vcenter_ip=test \
   -v vcenter_user=test \
   -v vcenter_password=test \
-  -v vcenter_templates=test \
-  -v vcenter_vms=test \
-  -v vcenter_disks=test \
-  -v vcenter_cluster=test
+  -v vcenter_templates_folder=test \
+  -v vcenter_vm_folder=test \
+  -v vcenter_disk_path=test \
+  -v vcenter_cluster=test \
+  -v vcenter_bosh_director_cluster=test
 
 echo "- vSphere (cloud-config)"
 bosh update-cloud-config vsphere/cloud-config.yml \

--- a/vsphere/cpi.yml
+++ b/vsphere/cpi.yml
@@ -3,9 +3,9 @@
   path: /releases/-
   value:
     name: bosh-vsphere-cpi
-    version: 34
-    url: https://bosh.io/d/github.com/cloudfoundry-incubator/bosh-vsphere-cpi-release?v=34
-    sha1: 6a4e6d05a4b50c3d4fa53bda1d5d552f5899f1a6
+    version: 38
+    url: https://bosh.io/d/github.com/cloudfoundry-incubator/bosh-vsphere-cpi-release?v=38
+    sha1: cd964bb1858d6533efb1192b00afac76e80cb602
 
 - type: replace
   path: /resource_pools/name=vms/stemcell?
@@ -48,14 +48,22 @@
     password: ((vcenter_password))
     datacenters:
     - name: ((vcenter_dc))
-      vm_folder: ((vcenter_vms))
-      template_folder: ((vcenter_templates))
-      datastore_pattern: ((vcenter_ds))
-      persistent_datastore_pattern: ((vcenter_ds))
-      disk_path: ((vcenter_disks))
-      clusters:
-      - ((vcenter_cluster)): {}
+      vm_folder: ((vcenter_vm_folder))
+      template_folder: ((vcenter_templates_folder))
+      datastore_pattern: ((vcenter_ds_ephemeral))
+      persistent_datastore_pattern: ((vcenter_ds_persistent))
+      disk_path: ((vcenter_disk_path))
+      clusters: ((vcenter_cluster))
 
 - type: replace
   path: /cloud_provider/properties/vcenter?
   value: *vcenter
+
+- type: replace
+  path: /cloud_provider/properties/vcenter/datacenters/0/clusters?
+  value: ((vcenter_bosh_director_cluster))
+
+- type: replace
+  path: /cloud_provider/properties/vcenter/datacenters/0/datastore_pattern?
+  value: ((vcenter_ds_persistent))
+


### PR DESCRIPTION
The vSphere implementation is currently a bit rudimentary. Those changes represent what I had to modify/add to get bosh-deployment running in a vSphere with 3 Clusters, where distributed port groups are only clusterwide, s3 is used as blob store and a second network interface is needed. 