### PR TITLE
Use m4 instance types, not m3

### DIFF
--- a/aws/cloud-config.yml
+++ b/aws/cloud-config.yml
@@ -12,11 +12,11 @@ azs:
 vm_types:
 - name: default
   cloud_properties:
-    instance_type: m3.medium
+    instance_type: m4.large
     ephemeral_disk: {size: 25_000}
 - name: large
   cloud_properties:
-    instance_type: m3.xlarge
+    instance_type: m4.xlarge
     ephemeral_disk: {size: 50_000}
 
 disk_types:

--- a/aws/cpi.yml
+++ b/aws/cpi.yml
@@ -17,7 +17,7 @@
 - type: replace
   path: /resource_pools/name=vms/cloud_properties?
   value:
-    instance_type: m3.xlarge
+    instance_type: m4.xlarge
     ephemeral_disk: {size: 25_000, type: gp2}
     availability_zone: ((az))
 


### PR DESCRIPTION
m3 instance types have been deprecated by aws in the us-east-1a availability zone.

fixes
```
[CLI] 2017/03/28 17:29:16 ERROR - Deploying: Creating instance 'bosh/0': Creating VM: Creating vm with stemcell cid 'ami-408e1d57 light': CPI 'create_vm' method responded with error: CmdError{"type":"Unknown","message":"Your requested instance type (m3.medium) is not supported in your requested Availability Zone (us-east-1a). Please retry your request by not specifying an Availability Zone or choosing us-east-1c, us-east-1b, us-east-1d, us-east-1e.","ok_to_retry":false}
```

Signed-off-by: Zak Auerbach <zauerbach@pivotal.io>