### PR TITLE
Add external IP config for CredHub

### DIFF
--- a/external-ip-not-recommended-credhub.yml
+++ b/external-ip-not-recommended-credhub.yml
@@ -1,0 +1,12 @@
+- type: replace
+  path: /variables/name=credhub_tls/options/common_name
+  value: ((external_ip))
+
+- type: replace
+  path: /variables/name=credhub_tls/options/alternative_names/-
+  value: ((external_ip))
+
+- type: replace
+  path: /instance_groups/name=bosh/jobs/name=credhub?/properties/credhub/user_management/uaa/url
+  value: "https://((external_ip)):8443"
+


### PR DESCRIPTION
Enables external access, by request of BBL team.