### PR TITLE
Bosh director is receiving certificate errors talking to credhub on 127.0.0.1

### DIFF
--- a/credhub.yml
+++ b/credhub.yml
@@ -43,7 +43,7 @@
   path: /instance_groups/name=bosh/properties/director/config_server?
   value:
     enabled: true
-    url: "https://127.0.0.1:8844/api/"
+    url: "https://((internal_ip)):8844/api/"
     ca_cert: ((credhub_tls.ca))
     uaa:
       url: "https://((internal_ip)):8443"


### PR DESCRIPTION
**TLDR** - This PR configures the BOSH director to connect to credhub over the hosts network IP address rather than `127.0.0.1` due to the common name of the credhub certificate.

**Details Below**
i provisioned a local BOSH director with UAA and credhub (details below).
```
bosh2 create-env ./bosh.yml \
--state ./state.json \
--vars-store ./creds.yml \
-o ./virtualbox/cpi.yml \
-o ./virtualbox/outbound-network.yml \
-o ./bosh-lite.yml \
-o ./bosh-lite-runc.yml \
-o ./jumpbox-user.yml \
-o ./uaa.yml \
-o ./credhub.yml \
-v director_name="Bosh Lite Director" \
-v internal_ip=192.168.50.6 \
-v internal_gw=192.168.50.1 \
-v internal_cidr=192.168.50.0/24 \
-v outbound_network_name=NatNetwork
```
While the deployment of the director was successful, attempts at deploying BOSH releases that used credhub for generated credentials failed with certificate errors.
```
+ name: concourse

+ variables:
+ - name: postgresql-concourse-password
+   type: password

Continue? [yN]: y

Task 5

04:11:05 | Preparing deployment: Preparing deployment (00:00:00)
            L Error: hostname "127.0.0.1" does not match the server certificate

04:11:05 | Error: hostname "127.0.0.1" does not match the server certificate

Started  Thu May 11 04:11:05 UTC 2017
Finished Thu May 11 04:11:05 UTC 2017
Duration 00:00:00
```

Inspecting the cert for the credhub `https://192.168.50.6:8844/` shows a common name of `192.168.50.6`.

