### PR TITLE
Add resource_pool to `cloud_provider`

### DIFF
--- a/vsphere/resource-pool.yml
+++ b/vsphere/resource-pool.yml
@@ -2,3 +2,7 @@
 - type: replace
   path: /instance_groups/name=bosh/properties/vcenter/datacenters/name=((vcenter_dc))/clusters/0/((vcenter_cluster))/resource_pool?
   value: ((vcenter_rp))
+
+- type: replace
+  path: /cloud_provider/properties/vcenter/datacenters/name=((vcenter_dc))/clusters/0/((vcenter_cluster))/resource_pool?
+  value: ((vcenter_rp))


### PR DESCRIPTION
- previously was only added to `instance_groups`, which meant that the VMs that the BOSH Director deployed were in the correct resource pool, but not the Director itself.