### PR TITLE
Allow Resource Pools to be configured by `vcenter_rp` variable

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -307,7 +307,8 @@ bosh create-env bosh.yml \
   -v vcenter_templates=test \
   -v vcenter_vms=test \
   -v vcenter_disks=test \
-  -v vcenter_cluster=test
+  -v vcenter_cluster=test \
+  -v vceneter_rp=test
 
 echo "- vCloud"
 bosh create-env bosh.yml \

--- a/vsphere/cpi.yml
+++ b/vsphere/cpi.yml
@@ -54,7 +54,7 @@
       persistent_datastore_pattern: ((vcenter_ds))
       disk_path: ((vcenter_disks))
       clusters:
-      - ((vcenter_cluster)): {}
+      - {((vcenter_cluster)): {resource_pool: ((vcenter_rp))}}
 
 - type: replace
   path: /cloud_provider/properties/vcenter?


### PR DESCRIPTION
Currently, with `Bosh init` I can configure a resource pool for BOSH and the vms it will provision. This PR enables that functionality within bosh-deployment. I also would like to make this variable optional, but don't know how. Any suggestions?