### PR TITLE
Replace hardcoded `8.8.8.8` DNS with `internal_dns` variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ $ bosh create-env ~/workspace/bosh-deployment/bosh.yml \
   -v internal_cidr=10.0.0.0/24 \
   -v internal_gw=10.0.0.1 \
   -v internal_ip=10.0.0.6 \
+  -v internal_dns=8.8.8.8 \
   --var-file private_key=~/Downloads/bosh.pem
 
 # Alias deployed Director
@@ -69,7 +70,8 @@ $ bosh -e bosh-1 update-cloud-config ~/workspace/bosh-deployment/aws/cloud-confi
   -v az=us-east-1b \
   -v subnet_id=subnet-... \
   -v internal_cidr=10.0.0.0/24 \
-  -v internal_gw=10.0.0.1
+  -v internal_gw=10.0.0.1 \
+  -v internal_dns=8.8.8.8
 
 # Upload specific stemcell
 $ bosh -e bosh-1 upload-stemcell https://...

--- a/aws/cloud-config.yml
+++ b/aws/cloud-config.yml
@@ -32,7 +32,7 @@ networks:
   - range: ((internal_cidr))
     gateway: ((internal_gw))
     azs: [z1, z2, z3]
-    dns: [8.8.8.8]
+    dns: [((internal_dns))]
     reserved: [((internal_gw))/30]
     cloud_properties:
       subnet: ((subnet_id))

--- a/bosh.yml
+++ b/bosh.yml
@@ -27,7 +27,7 @@ networks:
   - range: ((internal_cidr))
     gateway: ((internal_gw))
     static: [((internal_ip))]
-    dns: [8.8.8.8]
+    dns: [((internal_dns))]
 
 instance_groups:
 - name: bosh

--- a/docker/cloud-config.yml
+++ b/docker/cloud-config.yml
@@ -16,7 +16,7 @@ networks:
   subnets:
   - azs: [z1, z2, z3]
     range: 10.245.0.0/16
-    dns: [8.8.8.8]
+    dns: [((internal_dns))]
     gateway: 10.245.0.1
     static: [10.245.0.34]
     cloud_properties:

--- a/docs/bosh-lite-on-vbox.md
+++ b/docs/bosh-lite-on-vbox.md
@@ -38,6 +38,7 @@
       -v internal_ip=192.168.50.6 \
       -v internal_gw=192.168.50.1 \
       -v internal_cidr=192.168.50.0/24 \
+      -v internal_dns=8.8.8.8 \
       -v outbound_network_name=NatNetwork
     ```
 

--- a/gcp/cloud-config.yml
+++ b/gcp/cloud-config.yml
@@ -34,7 +34,7 @@ networks:
   - range: ((internal_cidr))
     gateway: ((internal_gw))
     azs: [z1, z2, z3]
-    dns: [8.8.8.8]
+    dns: [((internal_dns))]
     cloud_properties:
       network_name: ((network))
       subnetwork_name: ((subnetwork))

--- a/openstack/cloud-config.yml
+++ b/openstack/cloud-config.yml
@@ -30,7 +30,7 @@ networks:
   - range: ((internal_cidr))
     gateway: ((internal_gw))
     azs: [z1, z2, z3]
-    dns: [8.8.8.8]
+    dns: [((internal_dns))]
     reserved: []
     cloud_properties:
       net_id: ((net_id))

--- a/softlayer/cloud-config.yml
+++ b/softlayer/cloud-config.yml
@@ -37,13 +37,13 @@ networks:
   - range: ((internal_cidr))
     gateway: ((internal_gw))
     azs: [z1, z2, z3]
-    dns: [((internal_ip)), 8.8.8.8, 10.0.80.11, 10.0.80.12]
+    dns: [((internal_ip)), ((internal_dns)), 10.0.80.11, 10.0.80.12]
     static: ((internal_static_ips))
     reserved: ((internal_reserved_ips))
 
 - name: dynamic
   type: dynamic
-  dns: [((internal_ip)), 8.8.8.8, 10.0.80.11, 10.0.80.12]
+  dns: [((internal_ip)), ((internal_dns)), 10.0.80.11, 10.0.80.12]
   cloud_properties:
     PrimaryNetworkComponent:
       NetworkVlan:

--- a/softlayer/cpi.yml
+++ b/softlayer/cpi.yml
@@ -39,14 +39,14 @@
 
 - type: replace
   path: /networks/name=default/subnets/0/dns
-  value: [8.8.8.8, 10.0.80.11, 10.0.80.12]
+  value: [((internal_dns)), 10.0.80.11, 10.0.80.12]
 
 - type: replace
   path: /networks/-
   value:
     name: dynamic
     type: dynamic
-    dns: [8.8.8.8, 10.0.80.11, 10.0.80.12]
+    dns: [((internal_dns)), 10.0.80.11, 10.0.80.12]
     cloud_properties:
       PrimaryNetworkComponent:
         NetworkVlan:

--- a/test.sh
+++ b/test.sh
@@ -34,6 +34,7 @@ bosh create-env bosh.yml \
   -v internal_cidr=test \
   -v internal_gw=test \
   -v internal_ip=test \
+  -v internal_dns=8.8.8.8 \
   -v access_key_id=test \
   -v secret_access_key=test \
   -v az=test \
@@ -53,6 +54,7 @@ bosh create-env bosh.yml \
   -v internal_cidr=test \
   -v internal_gw=test \
   -v internal_ip=test \
+  -v internal_dns=8.8.8.8 \
   -v access_key_id=test \
   -v secret_access_key=test \
   -v az=test \
@@ -73,6 +75,7 @@ bosh create-env bosh.yml \
   -v internal_cidr=test \
   -v internal_gw=test \
   -v internal_ip=test \
+  -v internal_dns=8.8.8.8 \
   -v access_key_id=test \
   -v secret_access_key=test \
   -v az=test \
@@ -94,6 +97,7 @@ bosh create-env bosh.yml \
   -v internal_cidr=test \
   -v internal_gw=test \
   -v internal_ip=test \
+  -v internal_dns=8.8.8.8 \
   -v access_key_id=test \
   -v secret_access_key=test \
   -v az=test \
@@ -112,6 +116,7 @@ bosh deploy bosh.yml \
   --vars-store $(mktemp ${vars_store_prefix}.XXXXXX) \
   -v director_name=test \
   -v internal_ip=test \
+  -v internal_dns=8.8.8.8 \
   -v access_key_id=test \
   -v secret_access_key=test \
   -v region=test \
@@ -129,7 +134,7 @@ bosh create-env bosh.yml \
   -v internal_cidr=test \
   -v internal_gw=test \
   -v internal_ip=test \
-  -v internal_dns=[8.8.8.8] \
+  -v internal_dns=8.8.8.8 \
   -v access_key_id=test \
   -v secret_access_key=test \
   -v az=test \
@@ -149,6 +154,7 @@ echo "- AWS (cloud-config)"
 bosh update-cloud-config aws/cloud-config.yml \
   -v internal_cidr=test \
   -v internal_gw=test \
+  -v internal_dns=8.8.8.8 \
   -v az=test \
   -v subnet_id=test
 
@@ -161,6 +167,7 @@ bosh create-env bosh.yml \
   -v internal_cidr=test \
   -v internal_gw=test \
   -v internal_ip=test \
+  -v internal_dns=8.8.8.8 \
   -v gcp_credentials_json=test \
   -v project_id=test \
   -v zone=test \
@@ -178,6 +185,7 @@ bosh create-env bosh.yml \
   -v internal_cidr=test \
   -v internal_gw=test \
   -v internal_ip=test \
+  -v internal_dns=8.8.8.8 \
   -v gcp_credentials_json=test \
   -v project_id=test \
   -v zone=test \
@@ -197,6 +205,7 @@ bosh create-env bosh.yml \
   -v internal_cidr=test \
   -v internal_gw=test \
   -v internal_ip=test \
+  -v internal_dns=8.8.8.8 \
   -v gcp_credentials_json=test \
   -v project_id=test \
   -v zone=test \
@@ -232,6 +241,7 @@ bosh create-env bosh.yml \
   -v internal_cidr=test \
   -v internal_gw=test \
   -v internal_ip=test \
+  -v internal_dns=8.8.8.8 \
   -v gcp_credentials_json=test \
   -v project_id=test \
   -v zone=test \
@@ -249,6 +259,7 @@ bosh create-env bosh.yml \
   -v internal_cidr=test \
   -v internal_gw=test \
   -v internal_ip=test \
+  -v internal_dns=8.8.8.8 \
   -v gcp_credentials_json=test \
   -v project_id=test \
   -v zone=test \
@@ -266,6 +277,7 @@ echo "- GCP (cloud-config)"
 bosh update-cloud-config gcp/cloud-config.yml \
   -v internal_cidr=test \
   -v internal_gw=test \
+  -v internal_dns=8.8.8.8 \
   -v zone=test \
   -v network=test \
   -v subnetwork=test \
@@ -280,6 +292,7 @@ bosh create-env bosh.yml \
   -v internal_cidr=test \
   -v internal_gw=test \
   -v internal_ip=test \
+  -v internal_dns=8.8.8.8 \
   -v auth_url=test \
   -v az=test \
   -v default_key_name=test \
@@ -296,6 +309,7 @@ echo "- Openstack (cloud-config)"
 bosh update-cloud-config openstack/cloud-config.yml \
   -v internal_cidr=test \
   -v internal_gw=test \
+  -v internal_dns=8.8.8.8 \
   -v az=test \
   -v net_id=test
 
@@ -308,6 +322,7 @@ bosh create-env bosh.yml \
   -v internal_cidr=test \
   -v internal_gw=test \
   -v internal_ip=test \
+  -v internal_dns=8.8.8.8 \
   -v network_name=test \
   -v vcenter_dc=test \
   -v vcenter_ds=test \
@@ -328,6 +343,7 @@ bosh create-env bosh.yml \
   -v internal_cidr=test \
   -v internal_gw=test \
   -v internal_ip=test \
+  -v internal_dns=8.8.8.8 \
   -v network_name=test \
   -v vcloud_url=test \
   -v vcloud_user=test \
@@ -339,6 +355,7 @@ echo "- vSphere (cloud-config)"
 bosh update-cloud-config vsphere/cloud-config.yml \
   -v internal_cidr=test \
   -v internal_gw=test \
+  -v internal_dns=8.8.8.8 \
   -v network_name=test \
   -v vcenter_cluster=test
 
@@ -351,6 +368,7 @@ bosh create-env bosh.yml \
   -v internal_cidr=10.0.0.0/24 \
   -v internal_gw=10.0.0.1 \
   -v internal_ip=10.0.0.4 \
+  -v internal_dns=8.8.8.8 \
   -v vnet_name=boshvnet-crp \
   -v subnet_name=Bosh \
   -v subscription_id=test \
@@ -371,6 +389,7 @@ bosh create-env bosh.yml \
   -v internal_cidr=10.0.0.0/24 \
   -v internal_gw=10.0.0.1 \
   -v internal_ip=10.0.0.4 \
+  -v internal_dns=8.8.8.8 \
   -v vnet_name=boshvnet-crp \
   -v subnet_name=Bosh \
   -v environment=AzureChinaCloud \
@@ -386,6 +405,7 @@ echo "- Azure (cloud-config)"
 bosh update-cloud-config azure/cloud-config.yml \
   -v internal_cidr=10.0.16.0/24 \
   -v internal_gw=10.0.16.1 \
+  -v internal_dns=8.8.8.8 \
   -v vnet_name=boshvnet-crp \
   -v subnet_name=CloudFoundry \
   -v security_group=nsg-cf
@@ -399,6 +419,7 @@ bosh create-env bosh.yml \
   -v director_name=vbox \
   -v internal_ip=192.168.56.6 \
   -v internal_gw=192.168.56.1 \
+  -v internal_dns=8.8.8.8 \
   -v internal_cidr=192.168.56.0/24
 
 echo "- VirtualBox with BOSH Lite with garden-runc"
@@ -412,6 +433,7 @@ bosh create-env bosh.yml \
   -v director_name=vbox \
   -v internal_ip=192.168.56.6 \
   -v internal_gw=192.168.56.1 \
+  -v internal_dns=8.8.8.8 \
   -v internal_cidr=192.168.56.0/24
 
 echo "- Warden (cloud-config)"
@@ -427,6 +449,7 @@ bosh create-env bosh.yml \
   -v internal_cidr=10.245.0.0/16 \
   -v internal_gw=10.245.0.1 \
   -v internal_ip=10.245.0.10 \
+  -v internal_dns=8.8.8.8 \
   -v docker_host=tcp://192.168.50.8:4243 \
   -v docker_tls=ca_cert \
   -v network=net3
@@ -442,6 +465,7 @@ bosh create-env bosh.yml \
   -v internal_cidr=10.245.0.0/16 \
   -v internal_gw=10.245.0.1 \
   -v internal_ip=10.245.0.10 \
+  -v internal_dns=8.8.8.8 \
   -v docker_host=unix:///var/run/docker.sock \
   -v network=net3
 

--- a/virtualbox/cloud-config.yml
+++ b/virtualbox/cloud-config.yml
@@ -28,7 +28,7 @@ networks:
   - range: ((internal_cidr))
     gateway: ((internal_gw))
     azs: [z1, z2, z3]
-    dns: [8.8.8.8]
+    dns: [((internal_dns))]
     reserved: []
     cloud_properties:
       name: ((network_name))

--- a/vsphere/cloud-config.yml
+++ b/vsphere/cloud-config.yml
@@ -37,7 +37,7 @@ networks:
   - range: ((internal_cidr))
     gateway: ((internal_gw))
     azs: [z1, z2, z3]
-    dns: [8.8.8.8]
+    dns: [((internal_dns))]
     reserved: []
     cloud_properties:
       name: ((network_name))

--- a/warden/cloud-config.yml
+++ b/warden/cloud-config.yml
@@ -15,7 +15,7 @@ networks:
   type: manual
   subnets:
   - azs: [z1, z2, z3]
-    dns: [8.8.8.8]
+    dns: [((internal_dns))]
     range: 10.244.0.0/24
     gateway: 10.244.0.1
     static: [10.244.0.34]


### PR DESCRIPTION
```bash
bosh-deployment$ grep -R 8.8.8.8 .
./aws/cloud-config.yml:    dns: [8.8.8.8]
./bosh.yml:    dns: [8.8.8.8]
./docker/cloud-config.yml:    dns: [8.8.8.8]
./gcp/cloud-config.yml:    dns: [8.8.8.8]
./openstack/cloud-config.yml:    dns: [8.8.8.8]
./softlayer/cloud-config.yml:    dns: [((internal_ip)), 8.8.8.8, 10.0.80.11, 10.0.80.12]
./softlayer/cloud-config.yml:  dns: [((internal_ip)), 8.8.8.8, 10.0.80.11, 10.0.80.12]
./softlayer/cpi.yml:  value: [8.8.8.8, 10.0.80.11, 10.0.80.12]
./softlayer/cpi.yml:    dns: [8.8.8.8, 10.0.80.11, 10.0.80.12]
./test.sh:  -v internal_dns=[8.8.8.8] \
./virtualbox/cloud-config.yml:    dns: [8.8.8.8]
./vsphere/cloud-config.yml:    dns: [8.8.8.8]
./warden/cloud-config.yml:    dns: [8.8.8.8]
```