### PR TITLE
vsphere: allow setting http(s) proxies

### DIFF
--- a/vsphere/cpi.yml
+++ b/vsphere/cpi.yml
@@ -59,3 +59,14 @@
 - type: replace
   path: /cloud_provider/properties/vcenter?
   value: *vcenter
+
+- type: replace
+  path: /instance_groups/name=bosh/properties/env?
+  value: &env
+    http_proxy: ((http_proxy))
+    https_proxy: ((https_proxy))
+    no_proxy: ((no_proxy))
+
+- type: replace
+  path: /cloud_provider/properties/env?
+  value: *env


### PR DESCRIPTION
The vsphere cpi allows [setting of http(s) proxies](https://github.com/cloudfoundry-incubator/bosh-vsphere-cpi-release/blob/v41/jobs/vsphere_cpi/spec#L131-L136). These options are currently not exposed in these templates.

This PR adds the possibility to set these values because we'd like to use a proxy in our setup (reason: https://github.com/cloudfoundry-incubator/bosh-vsphere-cpi-release/issues/30)