### PR TITLE
Change default disk from D1 to D1_v2 

### DIFF
--- a/azure/cpi.yml
+++ b/azure/cpi.yml
@@ -17,7 +17,7 @@
 - type: replace
   path: /resource_pools/name=vms/cloud_properties?
   value:
-    instance_type: Standard_D1
+    instance_type: Standard_D1_v2
 
 - type: replace
   path: /networks/name=default/subnets/0/cloud_properties?

--- a/azure/custom-environment.yml
+++ b/azure/custom-environment.yml
@@ -2,3 +2,7 @@
 - type: replace
   path: /instance_groups/name=bosh/properties/azure/environment
   value: ((environment))
+
+- type: replace
+  path: /cloud_provider/properties/azure/environment
+  value: ((environment))


### PR DESCRIPTION
This PR changes the default disk from Standard_D1 to Standard_D1_v2 which is supported in all 4 Azure Clouds.
- AzureCloud
- AzureUSGovernment
- AzureGermanCloud
- AzureChinaCloud

It also fixes a bug in the custom-environment.yml where the environment was only getting reset in one location but required a second to be reset. 