### PR TITLE
remove leading prompt from multiline instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,15 +34,15 @@ See [test.sh](test.sh) for example usage of different ops files.
 * AWS (below)
 
 ```
-$ git clone https://github.com/cloudfoundry/bosh-deployment ~/workspace/bosh-deployment
+git clone https://github.com/cloudfoundry/bosh-deployment ~/workspace/bosh-deployment
 
 # Create a directory to keep Director deployment
-$ mkdir -p ~/deployments/bosh-1
+mkdir -p ~/deployments/bosh-1
 
-$ cd ~/deployments/bosh-1
+cd ~/deployments/bosh-1
 
 # Deploy a Director -- ./creds.yml is generated automatically
-$ bosh create-env ~/workspace/bosh-deployment/bosh.yml \
+bosh create-env ~/workspace/bosh-deployment/bosh.yml \
   --state ./state.json \
   -o ~/workspace/bosh-deployment/aws/cpi.yml \
   --vars-store ./creds.yml \
@@ -60,31 +60,31 @@ $ bosh create-env ~/workspace/bosh-deployment/bosh.yml \
   --var-file private_key=~/Downloads/bosh.pem
 
 # Alias deployed Director
-$ bosh -e 10.0.0.6 --ca-cert <(bosh int ./creds.yml --path /director_ssl/ca) alias-env bosh-1
+bosh -e 10.0.0.6 --ca-cert <(bosh int ./creds.yml --path /director_ssl/ca) alias-env bosh-1
 
 # Log in to the Director
-$ export BOSH_CLIENT=admin
-$ export BOSH_CLIENT_SECRET=`bosh int ./creds.yml --path /admin_password`
+export BOSH_CLIENT=admin
+export BOSH_CLIENT_SECRET=`bosh int ./creds.yml --path /admin_password`
 
 # Update cloud config -- single az
-$ bosh -e bosh-1 update-cloud-config ~/workspace/bosh-deployment/aws/cloud-config.yml \
+bosh -e bosh-1 update-cloud-config ~/workspace/bosh-deployment/aws/cloud-config.yml \
   -v az=us-east-1b \
   -v subnet_id=subnet-... \
   -v internal_cidr=10.0.0.0/24 \
   -v internal_gw=10.0.0.1
 
 # Upload specific stemcell
-$ bosh -e bosh-1 upload-stemcell https://...
+bosh -e bosh-1 upload-stemcell https://...
 
 # Get a deployment running
-$ git clone https://github.com/cppforlife/zookeeper-release ~/workspace/zookeeper-release
-$ bosh -e bosh-1 -d zookeeper deploy ~/workspace/zookeeper-release/manifests/zookeeper.yml
+git clone https://github.com/cppforlife/zookeeper-release ~/workspace/zookeeper-release
+bosh -e bosh-1 -d zookeeper deploy ~/workspace/zookeeper-release/manifests/zookeeper.yml
 ```
 
 To generate creds (without deploying anything) or just to check if your manifest builds:
 
 ```
-$ bosh int ~/workspace/bosh-deployment/bosh.yml \
+bosh int ~/workspace/bosh-deployment/bosh.yml \
   --var-errs \
   -o ~/workspace/bosh-deployment/aws/cpi.yml \
   --vars-store ./creds.yml \

--- a/docs/bosh-lite-on-vbox.md
+++ b/docs/bosh-lite-on-vbox.md
@@ -16,17 +16,17 @@
 1. Install Director
 
     ```
-    $ git clone https://github.com/cloudfoundry/bosh-deployment ~/workspace/bosh-deployment
+    git clone https://github.com/cloudfoundry/bosh-deployment ~/workspace/bosh-deployment
 
-    $ mkdir -p ~/deployments/vbox
+    mkdir -p ~/deployments/vbox
 
-    $ cd ~/deployments/vbox
+    cd ~/deployments/vbox
     ```
 
     Below command will try automatically create/enable Host-only network 192.168.50.0/24 ([details](https://github.com/cppforlife/bosh-virtualbox-cpi-release/blob/master/docs/networks-host-only.md)) and NAT network 'NatNetwork' with DHCP enabled ([details](https://github.com/cppforlife/bosh-virtualbox-cpi-release/blob/master/docs/networks-nat-network.md)).
 
     ```
-    $ bosh create-env ~/workspace/bosh-deployment/bosh.yml \
+    bosh create-env ~/workspace/bosh-deployment/bosh.yml \
       --state ./state.json \
       -o ~/workspace/bosh-deployment/virtualbox/cpi.yml \
       -o ~/workspace/bosh-deployment/virtualbox/outbound-network.yml \
@@ -44,36 +44,36 @@
 1. Alias and log into the Director
 
     ```
-    $ bosh -e 192.168.50.6 --ca-cert <(bosh int ./creds.yml --path /director_ssl/ca) alias-env vbox
-    $ export BOSH_CLIENT=admin
-    $ export BOSH_CLIENT_SECRET=`bosh int ./creds.yml --path /admin_password`
+    bosh -e 192.168.50.6 --ca-cert <(bosh int ./creds.yml --path /director_ssl/ca) alias-env vbox
+    export BOSH_CLIENT=admin
+    export BOSH_CLIENT_SECRET=`bosh int ./creds.yml --path /admin_password`
     ```
 
 1. Upload BOSH Lite stemcell
 
     ```
-    $ bosh -e vbox upload-stemcell https://bosh.io/d/stemcells/bosh-warden-boshlite-ubuntu-trusty-go_agent?v=3421.9 \
+    bosh -e vbox upload-stemcell https://bosh.io/d/stemcells/bosh-warden-boshlite-ubuntu-trusty-go_agent?v=3421.9 \
       --sha1 1396d7877204e630b9e77ae680f492d26607461d
     ```
 
 1. Update cloud config
 
     ```
-    $ bosh -e vbox update-cloud-config ~/workspace/bosh-deployment/warden/cloud-config.yml
+    bosh -e vbox update-cloud-config ~/workspace/bosh-deployment/warden/cloud-config.yml
     ```
 
 1. Deploy example deployment
 
     ```
-    $ bosh -e vbox -d zookeeper deploy <(wget -O- https://raw.githubusercontent.com/cppforlife/zookeeper-release/master/manifests/zookeeper.yml)
+    bosh -e vbox -d zookeeper deploy <(wget -O- https://raw.githubusercontent.com/cppforlife/zookeeper-release/master/manifests/zookeeper.yml)
     ```
 
 1. Optionally, set up a local route for `bosh ssh` command
 
     ```
-    $ sudo route add -net 10.244.0.0/16    192.168.50.6 # Mac OS X
-    $ sudo route add -net 10.244.0.0/16 gw 192.168.50.6 # Linux
-    $ route add           10.244.0.0/16    192.168.50.6 # Windows
+    sudo route add -net 10.244.0.0/16    192.168.50.6 # Mac OS X
+    sudo route add -net 10.244.0.0/16 gw 192.168.50.6 # Linux
+    route add           10.244.0.0/16    192.168.50.6 # Windows
     ```
 
 1. In case you need to SSH into the Director VM, see [Jumpbox user](jumpbox-user.md).

--- a/docs/jumpbox-user.md
+++ b/docs/jumpbox-user.md
@@ -9,7 +9,7 @@ It's recommended:
 To obtain SSH access specifically to the Director VM you can opt into `jumpbox-user.yml` ops file. It will add a `jumpbox` user to the VM (by using `user_add` job from cloudfoundry/os-conf-release).
 
 ```
-$ bosh int creds.yml --path /jumpbox_ssh/private_key > jumpbox.key
-$ chmod 600 jumpbox.key
-$ ssh jumpbox@<external-or-internal-ip> -i jumpbox.key
+bosh int creds.yml --path /jumpbox_ssh/private_key > jumpbox.key
+chmod 600 jumpbox.key
+ssh jumpbox@<external-or-internal-ip> -i jumpbox.key
 ```


### PR DESCRIPTION
Thoughts?

I am generally annoyed at these when I setup bosh-deployment on virtualbox. I find that the `$` is good for distinguishing between input/output in examples, but in instructions with no output it becomes a hindrance to copy/pasting multi-line segments.