### PR TITLE
Add reserved IP range for gcp; to protect from director VM etc

### DIFF
--- a/gcp/cloud-config.yml
+++ b/gcp/cloud-config.yml
@@ -35,6 +35,7 @@ networks:
     gateway: ((internal_gw))
     azs: [z1, z2, z3]
     dns: [8.8.8.8]
+    reserved: [((internal_gw))/30]
     cloud_properties:
       network_name: ((network))
       subnetwork_name: ((subnetwork))


### PR DESCRIPTION
The https://github.com/cloudfoundry-incubator/bosh-google-cpi-release/tree/master/docs/bosh terraform plan places the bastion/nat/bosh in `10.0.0.2`, `10.0.0.3` and `10.0.0.4`. This PR adds a reserved range to cover these.

![screen shot 2017-07-14 at 12 26 20 pm](https://user-images.githubusercontent.com/108/28195767-baedc218-688f-11e7-8fb7-72a9062a621f.png)
