### PR TITLE
Reuse bosh director database for PowerDNS

### DIFF
--- a/powerdns.yml
+++ b/powerdns.yml
@@ -13,7 +13,7 @@
   value:
     address: ((internal_ip))
     db:
-      database: powerdns
+      database: bosh
       host: 127.0.0.1
       user: postgres
       password: ((postgres_password))


### PR DESCRIPTION
The database `powerdns` is not available.
So the deployment of BOSH director fails.