### PR TITLE
Enable ephemeral_external_ip on GCP

### DIFF
--- a/gcp/cpi.yml
+++ b/gcp/cpi.yml
@@ -31,7 +31,7 @@
   value:
     network_name: ((network))
     subnetwork_name: ((subnetwork))
-    ephemeral_external_ip: false
+    ephemeral_external_ip: true
     tags: ((tags))
 
 # Add CPI job


### PR DESCRIPTION
There are a few reasons I'm suggesting this change:
- BOSH director on GCP doesn't have internet access without this, which
seems to make CPI calls fail
- Folks (e.g. bosh-bootloader) appear to then solve this problem by using
external-ip-not-recommended.yml opsfile which seems sub-optimal,
because:
  - It requires a static external IP address
  - It unnecessarily binds services to the external IP
  - It seems from the name, that it isn't recommended
- Seems gcp/cloud-config.yml intends for all other VMs in the cloud to
have this anyway