### PR TITLE
Adds managed disks option

### DIFF
--- a/azure/use-managed-disks.yml
+++ b/azure/use-managed-disks.yml
@@ -1,0 +1,14 @@
+---
+- type: replace
+  path: /instance_groups/name=bosh/properties/azure/use_managed_disks?
+  value: true
+
+- type: remove
+  path: /instance_groups/name=bosh/properties/azure/storage_account_name
+
+- type: replace
+  path: /cloud_provider/properties/azure/use_managed_disks?
+  value: true
+
+- type: remove
+  path: /cloud_provider/properties/azure/storage_account_name


### PR DESCRIPTION
The default config uses unmanaged disks in Azure. This will allow the director to be configured with managed disks.