### PR TITLE
Precompile credhub release

### DIFF
--- a/ci/compiled-releases/pipeline.yml
+++ b/ci/compiled-releases/pipeline.yml
@@ -302,7 +302,7 @@ jobs:
         - get: bosh-deployment
         - get: credhub-release
           version:
-            version: "1.0.1"
+            version: "1.2.0"
         - get: ubuntu-trusty-3421-stemcell
           version:
             version: "3421.9"


### PR DESCRIPTION
Then in #113 precompiled credhub release can be used instead.