### PR TITLE
Add blobstore gcs ops file

### DIFF
--- a/gcp/gcs-blobstore.yml
+++ b/gcp/gcs-blobstore.yml
@@ -1,0 +1,14 @@
+- type: replace
+  path: /instance_groups/name=bosh/properties/blobstore?
+  value:
+    provider: gcs
+    bucket_name: ((bucket_name))
+    json_key: ((director_gcs_credentials_json))
+
+- type: remove
+  path: /instance_groups/name=bosh/jobs/name=blobstore
+
+- type: replace
+  path: /instance_groups/name=bosh/properties/agent/blobstore?
+  value:
+    json_key: ((agent_gcs_credentials_json))


### PR DESCRIPTION
Enables GCS blobstore

required permissions for [director_gcs_credentials_json](https://www.pivotaltracker.com/file_attachments/83522429/download?inline=true) and [agent_gcs_credentials_json](https://www.pivotaltracker.com/file_attachments/83522436/download?inline=true)