### PR TITLE
warden: update to garden-runc-release 1.9.2

### DIFF
--- a/bosh-lite-grootfs.yml
+++ b/bosh-lite-grootfs.yml
@@ -1,0 +1,41 @@
+- type: replace
+  path: /releases/-
+  value:
+    name: grootfs
+    version: "0.24.0"
+    url: https://bosh.io/d/github.com/cloudfoundry/grootfs-release?v=0.24.0
+    sha1: b342db5da3a7bd7bb2e81c2f6456d75cf38e9e0c
+
+- type: replace
+  path: /instance_groups/name=bosh/jobs/name=garden/properties?/garden/image_plugin?
+  value: /var/vcap/packages/grootfs/bin/grootfs
+
+- type: replace
+  path: /instance_groups/name=bosh/jobs/name=garden/properties/garden/image_plugin_extra_args?
+  value:
+    - --config
+    - /var/vcap/jobs/grootfs/config/grootfs_config.yml
+
+- type: replace
+  path: /instance_groups/name=bosh/jobs/name=garden/properties/garden/privileged_image_plugin?
+  value: /var/vcap/packages/grootfs/bin/grootfs
+
+- type: replace
+  path: /instance_groups/name=bosh/jobs/name=garden/properties/garden/privileged_image_plugin_extra_args?
+  value:
+    - --config
+    - /var/vcap/jobs/grootfs/config/privileged_grootfs_config.yml
+
+- type: replace
+  path: /instance_groups/name=bosh/jobs/-
+  value:
+    name: grootfs
+    release: grootfs
+    properties:
+      grootfs:
+        driver: btrfs
+        log_level: debug
+
+- type: replace
+  path: /instance_groups/name=bosh/properties/warden_cpi/actions?/expand_stemcell_tarball
+  value: false

--- a/bosh-lite-runc.yml
+++ b/bosh-lite-runc.yml
@@ -9,12 +9,12 @@
   path: /releases/-
   value:
     name: garden-runc
-    version: "1.1.1"
-    url: https://s3.amazonaws.com/bosh-compiled-release-tarballs/garden-runc-1.1.1-ubuntu-trusty-3421.9-20170621-054813-858784694-20170621054819.tgz?versionId=S53sWxU6eE_ChRsAnCCkzvi_JT9RGlNl
-    sha1: 9ff57b5d8467fb49d8f383a626b5f8f64e9efb76
+    version: "1.9.2"
+    url: https://storage.googleapis.com/cf-deployment-compiled-releases/garden-runc-1.9.2-ubuntu-trusty-3445.2-20170818-131651-237607908.tgz
+    sha1: 9f3c36f4d8eb53a56f12720b8fa91e36c852f617
 
 - type: replace
-  path: /instance_groups/name=bosh/properties/garden
+  path: /instance_groups/name=bosh/jobs/name=garden/properties?/garden
   value:
     listen_network: tcp
     listen_address: 127.0.0.1:7777

--- a/warden/cpi-grootfs.yml
+++ b/warden/cpi-grootfs.yml
@@ -1,0 +1,4 @@
+---
+- type: replace
+  path: /cloud_provider/properties/warden_cpi/actions?/expand_stemcell_tarball
+  value: false

--- a/warden/cpi.yml
+++ b/warden/cpi.yml
@@ -9,8 +9,8 @@
 - type: replace
   path: /resource_pools/name=vms/stemcell?
   value:
-    url: https://bosh.io/d/stemcells/bosh-warden-boshlite-ubuntu-trusty-go_agent?v=3421.9
-    sha1: 1396d7877204e630b9e77ae680f492d26607461d
+    url: https://bosh.io/d/stemcells/bosh-warden-boshlite-ubuntu-trusty-go_agent?v=3445.2
+    sha1: 7ff35e03ab697998ded7a1698fe6197c1a5b2258
 
 # Configure VM size
 - type: replace

--- a/warden/cpi.yml
+++ b/warden/cpi.yml
@@ -3,8 +3,8 @@
   path: /releases/name=bosh-warden-cpi
   value:
     name: bosh-warden-cpi
-    url: https://bosh.io/d/github.com/cppforlife/bosh-warden-cpi-release?v=34
-    sha1: 5b102afe81bea5927983575aeafddbd93f6a21a5
+    url: https://bosh.io/d/github.com/cppforlife/bosh-warden-cpi-release?v=35
+    sha1: d1c79c61c5a1c3664e5456cc6cbce34f2111f2d7
 
 - type: replace
   path: /resource_pools/name=vms/stemcell?


### PR DESCRIPTION
Also uses compile release from cf-deployment for stemcell 3445, which has been updated on warden/cpi.yml aswell.