### PR TITLE
Link to options on how to access BOSH after environment is created

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,18 @@ See [test.sh](test.sh) for example usage of different ops files.
 * [Create an environment](https://bosh.io/docs/init.html)
     * [On Local machine (BOSH Lite)](https://bosh.io/docs/bosh-lite.html)
     * [On AWS](https://bosh.io/docs/init-aws.html)
-      * [Expose Director on a Public IP](https://bosh.io/docs/init-external-ip.html)
     * [On Azure](https://bosh.io/docs/init-azure.html)
     * [On OpenStack](https://bosh.io/docs/init-openstack.html)
     * [On vSphere](https://bosh.io/docs/init-vsphere.html)
     * [On vCloud](https://bosh.io/docs/init-vcloud.html)
     * [On SoftLayer](https://bosh.io/docs/init-softlayer.html)
     * [On Google Compute Platform](https://bosh.io/docs/init-google.html)
+* Access your BOSH director
+    * Through a VPN
+	    * [`bosh create-env`, OpenVPN option](https://github.com/dpb587/openvpn-bosh-release)
+    * Through a jumpbox
+	    * [`bosh create-env` option](https://github.com/cppforlife/jumpbox-deployment)
+    * [Expose Director on a Public IP](https://bosh.io/docs/init-external-ip.html) (not recommended)
 
 Please ensure you have security groups setup correctly. i.e:
 


### PR DESCRIPTION
@cppforlife 
- I realize the original structure matches http://bosh.io/docs#install; maybe update there too?
- What's your opinion on linking to non-`cloudfoundry` Github org repos?
- Do you know of other options?

@divyabhargov @kmacoskey @doty-pivotal @l-wang @pivotal-mike you have another VPN option, I know. Want to reference it here?

For Github issue #126