### PR TITLE
Update cpi.yml for 'datacenter' attribute

### DIFF
--- a/softlayer/cpi.yml
+++ b/softlayer/cpi.yml
@@ -32,6 +32,8 @@
     hourlyBillingFlag: true
     networkComponents:
     - maxSpeed: 100
+    datacenter:
+      name: ((sl_datacenter))
 
 - type: replace
   path: /disk_pools/name=disks/disk_size


### PR DESCRIPTION
## Issue
When I deployed bosh using `bosh create-env bosh.yml` command, the following error occurred.
```
Deploying:
  Creating instance 'bosh/0':
    Creating VM:
      Creating vm with stemcell cid '1654181':
        CPI 'create_vm' method responded with error: CmdError{"type":"Bosh::Clouds::CloudError","message":"Creating Virtual_Guest with agent ID 'd0c577b8-7f33-4a53-6e47-80b430f8cbe4': Creating VirtualGuest from SoftLayer client: * Datacenter.Name: specifies which datacenter the instance is to be provisioned in is required and cannot be empty\n","ok_to_retry":false}

```

## Suggestion
So, I added the 'datacenter' attribute in `softlayer/cpi.yml`.
Please review whether this is the right solution.