### PR TITLE
Bump to CredHub 1.3.0

### DIFF
--- a/ci/compiled-releases/pipeline.yml
+++ b/ci/compiled-releases/pipeline.yml
@@ -317,7 +317,7 @@ jobs:
         - get: bosh-deployment
         - get: credhub-release
           version:
-            version: "1.2.0"
+            version: "1.3.0"
         - get: ubuntu-trusty-stemcell
           version:
             version: "3445.7"

--- a/credhub.yml
+++ b/credhub.yml
@@ -2,9 +2,9 @@
   path: /releases/-
   value:
     name: credhub
-    version: 1.2.0
-    url: https://bosh.io/d/github.com/pivotal-cf/credhub-release?v=1.2.0
-    sha1: b28b53dc55c1f1c8ef37edddc9ecad76e16f7d77
+    version: 1.3.0
+    url: https://bosh.io/d/github.com/pivotal-cf/credhub-release?v=1.3.0
+    sha1: 2b13fa390bd1b0ec7ca69537d1ac67b101cf0f7d
 
 - type: replace
   path: /instance_groups/name=bosh/jobs/-


### PR DESCRIPTION
Bump CredHub version to 1.3.0. No changes needed to manifest config.