### PR TITLE
Add external-ip-not-recommended-credhub.yml

### DIFF
--- a/external-ip-not-recommended-credhub.yml
+++ b/external-ip-not-recommended-credhub.yml
@@ -1,0 +1,15 @@
+- type: replace
+  path: /variables/name=credhub_tls/options/alternative_names/-
+  value: ((external_ip))
+
+- type: replace
+  path: /instance_groups/name=bosh/jobs/name=credhub/properties/credhub/authentication/uaa/url
+  value: "https://((external_ip)):8443"
+
+- type: replace
+  path: /instance_groups/name=bosh/properties/director/config_server/url
+  value: "https://((external_ip)):8844/api/"
+
+- type: replace
+  path: /instance_groups/name=bosh/properties/director/config_server/uaa/url
+  value: "https://((external_ip)):8443"


### PR DESCRIPTION
Is there any reason why there is't `external-ip-not-recommended-credhub.yml`?