### PR TITLE
Fixed iam-instance-profile ops-file

### DIFF
--- a/aws/iam-instance-profile.yml
+++ b/aws/iam-instance-profile.yml
@@ -3,7 +3,13 @@
   path: /resource_pools/name=vms/cloud_properties/access_key_id?
 
 - type: remove
+  path: /cloud_provider/properties/aws/access_key_id
+
+- type: remove
   path: /resource_pools/name=vms/cloud_properties/secret_access_key?
+
+- type: remove
+  path: /cloud_provider/properties/aws/secret_access_key
 
 - type: replace
   path: /resource_pools/name=vms/cloud_properties/iam_instance_profile?
@@ -17,4 +23,8 @@
 
 - type: replace
   path: /instance_groups/name=bosh/properties/aws/credentials_source?
+  value: env_or_profile
+
+- type: replace
+  path: /cloud_provider/properties/aws/credentials_source?
   value: env_or_profile


### PR DESCRIPTION
The access_key_id and secret_access_key still existed in cloud_provider, these are now removed.  The cloud_provider block also contains a `aws/credentials_source` property that I changed to reflect the use of an iam-instance-profile (`env_or_profile`).