### PR TITLE
Update BOSH-Lite garden-runc to v1.9.4

### DIFF
--- a/bosh-lite-runc.yml
+++ b/bosh-lite-runc.yml
@@ -9,9 +9,9 @@
   path: /releases/-
   value:
     name: garden-runc
-    version: "1.9.2"
-    url: https://s3.amazonaws.com/bosh-compiled-release-tarballs/garden-runc-1.9.2-ubuntu-trusty-3445.7-20170901-174605-756404527-20170901174611.tgz?versionId=ulUDAhslbDcla1qt6_D1.HkLRYbES18p
-    sha1: 8028f7e832b32f305bbd45b1636be23334805e2f
+    version: "1.9.4"
+    url: https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=1.9.4
+    sha1: 9cccd7685ac075ad6956cba3ab5881e3435cd7e3
 
 - type: replace
   path: /instance_groups/name=bosh/jobs/name=garden/properties?/garden

--- a/ci/compiled-releases/pipeline.yml
+++ b/ci/compiled-releases/pipeline.yml
@@ -459,7 +459,7 @@ jobs:
           - get: bosh-deployment
           - get: garden-runc
             version:
-              version: "1.9.2"
+              version: "1.9.4"
           - get: ubuntu-trusty-stemcell
             version:
               version: "3445.11"


### PR DESCRIPTION
Garden-runc v1.9.4 running in a garden-runc v1.9.2 container cannot create nested containers.

/cc @julz