### PR TITLE
For default use-cases, it is better to use the default CA.

### DIFF
--- a/credhub.yml
+++ b/credhub.yml
@@ -93,19 +93,10 @@
 - type: replace
   path: /variables/-
   value:
-    name: credhub_ca
-    type: certificate
-    options:
-      is_ca: true
-      common_name: "CredHub CA"
-
-- type: replace
-  path: /variables/-
-  value:
     name: credhub_tls
     type: certificate
     options:
-      ca: credhub_ca
+      ca: default_ca
       common_name: ((internal_ip))
       alternative_names: [((internal_ip))]
 


### PR DESCRIPTION
This means that clients of CredHub need only be configured with one CA cert.

(they also need a CA cert for UAA, which already uses the default CA)

Fixes https://github.com/cloudfoundry/bosh-deployment/issues/156

Revert "Added CredHub CA"

This reverts commit 462770946ec0668a0d8368a3cabed698bf916aa9.

I tested to see that happens if I re-deployed an existing environment with this change. Presumably since the `credhub_tls` variable already existed, it didn't try to create a new one, even though the `ca` option had changed. If that's intentional, that seems fairly safe and easy to reason about.

I deleted the old `credhub_tls` from my `creds.yml`, then re-deployed, and verified the new deployment used the new certificate signed by the `default_ca`, which it did.