### PR TITLE
updated azure cloud-config and cpi to accept a vnet resource group name

### DIFF
--- a/azure/cloud-config.yml
+++ b/azure/cloud-config.yml
@@ -27,6 +27,7 @@ networks:
     dns: [168.63.129.16]
     reserved: [((internal_gw))/30]
     cloud_properties:
+      resource_group_name: ((vnet_resource_group_name))
       virtual_network_name: ((vnet_name))
       subnet_name: ((subnet_name))
       security_group: ((security_group))

--- a/azure/cpi.yml
+++ b/azure/cpi.yml
@@ -22,6 +22,7 @@
 - type: replace
   path: /networks/name=default/subnets/0/cloud_properties?
   value:
+    resource_group_name: ((vnet_resource_group_name))
     virtual_network_name: ((vnet_name))
     subnet_name: ((subnet_name))
 


### PR DESCRIPTION
updated cloud-config.yml and cpi.yml file to accept a resource group name for vnet in azure if the vnet is shared for different deployments.