### PR TITLE
Add Ephermeral IP on GCP Ops File

### DIFF
--- a/gcp/ephemeral_ip.yml
+++ b/gcp/ephemeral_ip.yml
@@ -1,0 +1,5 @@
+---
+# add ephemeral ip for internet access
+- type: replace
+  path: /networks/name=default/subnets/0/cloud_properties/ephemeral_external_ip
+  value: true


### PR DESCRIPTION
When deploying BOSH directors on GCP and attempting to have the director pull stemcells from the cloud or pull releases from the cloud we need to access the internet. With GCP the best way I have found to have the director access the internet is to add an ephemeral IP. That is what this PR does.