### PR TITLE
add vm_types to support cf-deployment contract

### DIFF
--- a/aws/cloud-config.yml
+++ b/aws/cloud-config.yml
@@ -14,6 +14,18 @@ vm_types:
   cloud_properties:
     instance_type: m4.large
     ephemeral_disk: {size: 25_000}
+- name: minimal
+  cloud_properties:
+    instance_type: m4.large
+    ephemeral_disk: {size: 25_000}
+- name: small
+  cloud_properties:
+    instance_type: m4.large
+    ephemeral_disk: {size: 25_000}
+- name: small-highmem
+  cloud_properties:
+    instance_type: m4.xlarge
+    ephemeral_disk: {size: 50_000}
 - name: large
   cloud_properties:
     instance_type: m4.xlarge

--- a/azure/cloud-config.yml
+++ b/azure/cloud-config.yml
@@ -7,6 +7,15 @@ vm_types:
 - name: default
   cloud_properties:
     instance_type: Standard_D1_v2
+- name: minimal
+  cloud_properties:
+    instance_type: Standard_D1_v2
+- name: small
+  cloud_properties:
+    instance_type: Standard_D1_v2
+- name: small-highmem
+  cloud_properties:
+    instance_type: Standard_D1_v2
 - name: large
   cloud_properties:
     instance_type: Standard_D3_v2

--- a/docker/cloud-config.yml
+++ b/docker/cloud-config.yml
@@ -5,6 +5,10 @@ azs:
 
 vm_types:
 - name: default
+- name: minimal
+- name: small
+- name: small-highmem
+- name: large
 
 disk_types:
 - name: default

--- a/gcp/cloud-config.yml
+++ b/gcp/cloud-config.yml
@@ -15,6 +15,21 @@ vm_types:
     machine_type: n1-standard-2
     root_disk_size_gb: 20
     root_disk_type: pd-ssd
+- name: minimal
+  cloud_properties:
+    machine_type: n1-standard-2
+    root_disk_size_gb: 20
+    root_disk_type: pd-ssd
+- name: small
+  cloud_properties:
+    machine_type: n1-standard-2
+    root_disk_size_gb: 20
+    root_disk_type: pd-ssd
+- name: small-highmem
+  cloud_properties:
+    machine_type: n1-standard-2
+    root_disk_size_gb: 50
+    root_disk_type: pd-ssd
 - name: large
   cloud_properties:
     machine_type: n1-standard-2

--- a/openstack/cloud-config.yml
+++ b/openstack/cloud-config.yml
@@ -13,6 +13,15 @@ vm_types:
 - name: default
   cloud_properties:
     instance_type: m1.small
+- name: minimal
+  cloud_properties:
+    instance_type: m1.small
+- name: small
+  cloud_properties:
+    instance_type: m1.small
+- name: small-highmem
+  cloud_properties:
+    instance_type: m1.xlarge
 - name: large
   cloud_properties:
     instance_type: m1.xlarge

--- a/softlayer/cloud-config.yml
+++ b/softlayer/cloud-config.yml
@@ -21,6 +21,50 @@ vm_types:
     domain: ((sl_vm_domain))
     datacenter:
       name: ((sl_datacenter))
+- name: minimal
+  cloud_properties:
+    bosh_ip: ((internal_ip))
+    startCpus:  4
+    maxMemory:  8192
+    ephemeralDiskSize: 100
+    hourlyBillingFlag: true
+    vmNamePrefix: ((sl_vm_name_prefix))
+    domain: ((sl_vm_domain))
+    datacenter:
+      name: ((sl_datacenter))
+- name: small
+  cloud_properties:
+    bosh_ip: ((internal_ip))
+    startCpus:  4
+    maxMemory:  8192
+    ephemeralDiskSize: 100
+    hourlyBillingFlag: true
+    vmNamePrefix: ((sl_vm_name_prefix))
+    domain: ((sl_vm_domain))
+    datacenter:
+      name: ((sl_datacenter))
+- name: small-highmem
+  cloud_properties:
+    bosh_ip: ((internal_ip))
+    startCpus:  4
+    maxMemory:  8192
+    ephemeralDiskSize: 100
+    hourlyBillingFlag: true
+    vmNamePrefix: ((sl_vm_name_prefix))
+    domain: ((sl_vm_domain))
+    datacenter:
+      name: ((sl_datacenter))
+- name: large
+  cloud_properties:
+    bosh_ip: ((internal_ip))
+    startCpus:  4
+    maxMemory:  8192
+    ephemeralDiskSize: 100
+    hourlyBillingFlag: true
+    vmNamePrefix: ((sl_vm_name_prefix))
+    domain: ((sl_vm_domain))
+    datacenter:
+      name: ((sl_datacenter))
 
 disk_types:
 - name: default

--- a/virtualbox/cloud-config.yml
+++ b/virtualbox/cloud-config.yml
@@ -9,6 +9,21 @@ vm_types:
     cpu: 2
     ram: 1024
     disk: 3240
+- name: minimal
+  cloud_properties:
+    cpu: 2
+    ram: 1024
+    disk: 3240
+- name: small
+  cloud_properties:
+    cpu: 2
+    ram: 1024
+    disk: 3240
+- name: small-highmem
+  cloud_properties:
+    cpu: 2
+    ram: 4096
+    disk: 30_240
 - name: large
   cloud_properties:
     cpu: 2

--- a/vsphere/cloud-config.yml
+++ b/vsphere/cloud-config.yml
@@ -18,6 +18,21 @@ vm_types:
     cpu: 2
     ram: 1024
     disk: 3240
+- name: minimal
+  cloud_properties:
+    cpu: 2
+    ram: 1024
+    disk: 3240
+- name: small
+  cloud_properties:
+    cpu: 2
+    ram: 1024
+    disk: 3240
+- name: small-highmem
+  cloud_properties:
+    cpu: 2
+    ram: 4096
+    disk: 30_240
 - name: large
   cloud_properties:
     cpu: 2

--- a/warden/cloud-config.yml
+++ b/warden/cloud-config.yml
@@ -5,6 +5,10 @@ azs:
 
 vm_types:
 - name: default
+- name: minimal
+- name: small
+- name: small-highmem
+- name: large
 
 disk_types:
 - name: default


### PR DESCRIPTION
For people who create their BOSH env using bosh-deployment this PR will add `vm_types` with names matching the contract of https://github.com/cloudfoundry/cf-deployment

This is also the set of `vm_types` I'm assuming exist in CFCR manifest in https://github.com/cloudfoundry-incubator/kubo-deployment/pull/237