### PR TITLE
Add toggle to disable humam readable for Openstack

### DIFF
--- a/openstack/disable-readable-vm-names.yml
+++ b/openstack/disable-readable-vm-names.yml
@@ -1,0 +1,6 @@
+- type: replace
+  path: /instance_groups/name=bosh/properties/openstack/human_readable_vm_names
+  value: false
+- type: replace
+  path: /cloud_provider/properties/openstack/human_readable_vm_names
+  value: false


### PR DESCRIPTION
Add ops-files to desactivate humam readabl for Openstack.

This is actually needed when using openstack as  cloud-provider in Kubernetes (ala Kubo).


