### PR TITLE
No pre-existing ssh_tunnel host required for external-ip-with-registry

### DIFF
--- a/external-ip-with-registry-not-recommended.yml
+++ b/external-ip-with-registry-not-recommended.yml
@@ -26,7 +26,7 @@
   value: https://mbus:((mbus_bootstrap_password))@((external_ip)):6868
 
 - type: replace
-  path: /cloud_provider/ssh_tunnel/host
+  path: /cloud_provider/ssh_tunnel/host?
   value: ((external_ip))
 
 - type: replace


### PR DESCRIPTION
Running `bosh create-env` with this ops file previously resulted in this error:

Expected to find a map key 'ssh_tunnel' for path '/cloud_provider/ssh_tunnel' (found map keys: 'cert', 'mbus', 'properties', 'template')