### PR TITLE
Do not reduce director disks to 20GB in Softlayer CPI

### DIFF
--- a/softlayer/cpi-dynamic.yml
+++ b/softlayer/cpi-dynamic.yml
@@ -34,10 +34,6 @@
     - maxSpeed: 100
 
 - type: replace
-  path: /disk_pools/name=disks/disk_size
-  value: 20_000
-
-- type: replace
   path: /networks/name=default/subnets/0/dns
   value: [8.8.8.8, 10.0.80.11, 10.0.80.12]
 

--- a/softlayer/cpi.yml
+++ b/softlayer/cpi.yml
@@ -34,10 +34,6 @@
     - maxSpeed: 100
 
 - type: replace
-  path: /disk_pools/name=disks/disk_size
-  value: 20_000
-
-- type: replace
   path: /networks/name=default/subnets/0/dns
   value: [8.8.8.8, 10.0.80.11, 10.0.80.12]
 


### PR DESCRIPTION
20GB is not big enough for current cf-deployments.