### PR TITLE
Need to specify 127.0.0.1 for blobstore/nats when using dynamic IP on SL

### DIFF
--- a/softlayer/cpi-dynamic.yml
+++ b/softlayer/cpi-dynamic.yml
@@ -95,3 +95,11 @@
 - type: replace
   path: /cloud_provider/properties/softlayer?
   value: *softlayer
+
+- type: replace
+  path: /instance_groups/name=bosh/properties/blobstore/address?
+  value: 127.0.0.1
+
+- type: replace
+  path: /instance_groups/name=bosh/properties/nats/address?
+  value: 127.0.0.1


### PR DESCRIPTION
The update is for deploying BOSH director on SL with dynamic IP, already tested. Please help merge, thanks.