### PR TITLE
Reserve 10.245.0.2-10.245.0.10 in docker cloud-config

### DIFF
--- a/docker/cloud-config.yml
+++ b/docker/cloud-config.yml
@@ -17,6 +17,8 @@ networks:
   - azs: [z1, z2, z3]
     range: 10.245.0.0/16
     dns: [8.8.8.8]
+    # IPs that will not be used for anything
+    reserved: [10.245.0.2-10.245.0.10]
     gateway: 10.245.0.1
     static: [10.245.0.34]
     cloud_properties:


### PR DESCRIPTION
When using the Docker BOSH CLI v2 container (bosh/cli2) to stand up a BOSH director and run through the Zookeeper deployment steps, the operator will run into the following issue:

```
Task 7 | 00:30:29 | Creating missing vms: zookeeper/eb92593f-e880-42f6-b696-31576ae5d613 (0)
Task 7 | 00:30:29 | Creating missing vms: zookeeper/1442654d-9562-4e9c-84ba-1c389d225304 (3)
Task 7 | 00:30:29 | Creating missing vms: zookeeper/39318440-d3c2-4997-b723-69259f51aaac (4)
Task 7 | 00:30:29 | Creating missing vms: zookeeper/b52a5562-e6a2-4145-a96d-84b7cb532ba1 (1)
Task 7 | 00:30:29 | Creating missing vms: zookeeper/c4c530be-3e36-4526-9bdb-bc4513b83a52 (2)
Task 7 | 00:31:23 | Creating missing vms: zookeeper/1442654d-9562-4e9c-84ba-1c389d225304 (3) (00:00:54)
                   L Error: CPI error 'Bosh::Clouds::CloudError' with message 'Creating VM with agent ID '{{803b7399-c39b-4cc1-bdb2-a55f2b3175
ed}}': Starting container: Error response from daemon: Address already in use' in 'create_vm' CPI method
Task 7 | 00:32:07 | Creating missing vms: zookeeper/c4c530be-3e36-4526-9bdb-bc4513b83a52 (2) (00:01:38)
Task 7 | 00:32:07 | Creating missing vms: zookeeper/b52a5562-e6a2-4145-a96d-84b7cb532ba1 (1) (00:01:38)
Task 7 | 00:32:07 | Creating missing vms: zookeeper/39318440-d3c2-4997-b723-69259f51aaac (4) (00:01:38)
Task 7 | 00:32:08 | Creating missing vms: zookeeper/eb92593f-e880-42f6-b696-31576ae5d613 (0) (00:01:39)
Task 7 | 00:32:11 | Error: CPI error 'Bosh::Clouds::CloudError' with message 'Creating VM with agent ID '{{803b7399-c39b-4cc1-bdb2-a55f2b3175e
d}}': Starting container: Error response from daemon: Address already in use' in 'create_vm' CPI method

Task 7 Started  Thu Mar  1 00:22:20 UTC 2018
Task 7 Finished Thu Mar  1 00:32:11 UTC 2018
Task 7 Duration 00:09:51
Task 7 error
```
This occurs because the cli2 container binds 10.245.0.3 during bosh create-env.  The 'expected' Docker networking (seen in run_checks.sh and the Docker cloud-config.yml) sets up 10.245.0.0/16 with the Director on 10.245.0.10, but doesn't reserve the CLI address to prevent a later conflict.  The example of a manual network provided at https://bosh.io/docs/networks.html gives a template for how to fix the issue:

```
...
    # IPs that will not be used for anything
    reserved: [10.245.0.2-10.245.0.10]
...