### PR TITLE
added support for disk encryption based on existing AMS KMS key

### DIFF
--- a/aws/encrypt-disk.yml
+++ b/aws/encrypt-disk.yml
@@ -1,0 +1,8 @@
+---
+- type: replace
+  path: /cloud_provider/properties/aws/encrypted?
+  value: true
+
+- type: replace
+  path: /cloud_provider/properties/aws/kms_key_arn?
+  value: ((encrypt_key))


### PR DESCRIPTION
This PR contains additions to the AWS config template and property replacement within the BOSH manifest to enable AWS disk encryption.