### PR TITLE
Move trusted certs ops file to misc directory.

### DIFF
--- a/misc/trusted-certs.yml
+++ b/misc/trusted-certs.yml
@@ -1,4 +1,4 @@
 ---
 - type: replace
   path: /instance_groups/name=bosh/properties/director/trusted_certs?
-  value: ((openstack_ca_cert))
+  value: ((trusted_certs))


### PR DESCRIPTION
Nothing about this file is specific to openstack.
It is more discoverable and easier to use in a more general location.

Fixes #152