### PR TITLE
split aws/iam-instance-profile ops file into 2:

### DIFF
--- a/aws/cloud-provider-iam-instance-profile.yml
+++ b/aws/cloud-provider-iam-instance-profile.yml
@@ -1,0 +1,14 @@
+---
+- type: remove
+  path: /cloud_provider/properties/aws/access_key_id
+
+- type: remove
+  path: /cloud_provider/properties/aws/secret_access_key
+
+- type: replace
+  path: /cloud_provider/properties/aws/credentials_source?
+  value: env_or_profile
+
+- type: replace
+  path: /cloud_provider/properties/aws/default_iam_instance_profile?
+  value: ((iam_instance_profile))

--- a/aws/iam-instance-profile.yml
+++ b/aws/iam-instance-profile.yml
@@ -1,13 +1,9 @@
 ---
 - type: remove
-  path: /cloud_provider/properties/aws/access_key_id
+  path: /resource_pools/name=vms/cloud_properties/access_key_id?
 
 - type: remove
-  path: /cloud_provider/properties/aws/secret_access_key
-
-- type: replace
-  path: /cloud_provider/properties/aws/credentials_source?
-  value: env_or_profile
+  path: /resource_pools/name=vms/cloud_properties/secret_access_key?
 
 - type: replace
   path: /resource_pools/name=vms/cloud_properties/iam_instance_profile?


### PR DESCRIPTION
* iam-instance-profile.yml to have the director use its profile when deploying vms
* cloud-provider-iam-instance-profile.yml to deploy the director using the cli host's instance profile

this should fix the problem described @ https://github.com/cloudfoundry/bosh-deployment/commit/b37a696baa170ea30a2e4478d7292bbcb614306f

Signed-off-by: Connor Braa <connor.braa@gmail.com>