### PR TITLE
add internal ntp support

### DIFF
--- a/misc/ntp.yml
+++ b/misc/ntp.yml
@@ -1,0 +1,6 @@
+- type: replace
+  path: /instance_groups/name=bosh/properties/ntp?
+  value: ((internal_ntp))
+- type: replace
+  path: /cloud_provider/properties/ntp?
+  value: ((internal_ntp))


### PR DESCRIPTION
not sure if this is the best way, but trying to add support for internal NTP infra similar to how DNS overrides are supported in dns.yml.

bosh interpolate -d bosh bosh.yml -o misc/ntp.yml -v internal_ntp='[ntp1.test.com,ntp2.test.com]' |grep ntp
    ntp:
    - ntp1.test.com
    - ntp2.test.com
    ntp:
    - ntp1.test.com
    - ntp2.test.com

not a big deal for public cloud, but have seen private IaaS (vmware) deploys where this was useful.