### PR TITLE
remove dns config

### DIFF
--- a/warden/cloud-config.yml
+++ b/warden/cloud-config.yml
@@ -15,7 +15,6 @@ networks:
   type: manual
   subnets:
   - azs: [z1, z2, z3]
-    dns: [8.8.8.8]
     range: 10.244.0.0/24
     gateway: 10.244.0.1
     static: [10.244.0.34]


### PR DESCRIPTION
if you have a host that does not have the default google dns `8.8.8.8` in there `resolv.conf`
then agents are not able to start inside the container because they can't adjust the `/etc/resolv.conf` which is inherited from the host