### PR TITLE
add OPS file for bosh-lite on softlayer

### DIFF
--- a/softlayer/add-sl-domain-to-lite-director.yml
+++ b/softlayer/add-sl-domain-to-lite-director.yml
@@ -1,0 +1,28 @@
+# INFO:
+# This OPS file is required to be able to ssh into bosh-lite instances using Socks 5 proxy.
+
+
+# Pre-start script is available from release version v19
+- type: replace
+  path: /releases/name=os-conf?
+  value:
+    name: os-conf
+    version: 19
+    url: https://bosh.io/d/github.com/cloudfoundry/os-conf-release?v=19
+    sha1: f515406949ee0bba0329d1ce4a7eb1679521eabd
+
+# map IP with internal Softlayer domain name
+- type: replace
+  path: /instance_groups/name=bosh/jobs/-
+  value:
+    name: pre-start-script
+    release: os-conf
+    properties:
+      script: |-
+        #!/bin/bash
+        mkdir -p /var/vcap/sys/log/pre-start-script
+        echo "ifconfig" >> /var/vcap/sys/log/pre-start-script/out.log
+        ifconfig >> /var/vcap/sys/log/pre-start-script/out.log
+        echo "$(ifconfig | grep -C1 eth0 | tail -n1 | grep -oE 'addr:[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' \
+          | grep -oE '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}') ((sl_vm_name_prefix)).((sl_vm_domain))" \
+          >> /etc/hosts

--- a/tests/run-checks.sh
+++ b/tests/run-checks.sh
@@ -476,6 +476,24 @@ bosh create-env bosh.yml \
 echo "- Docker (cloud-config)"
 bosh update-cloud-config docker/cloud-config.yml -v network=net3
 
+echo "- Softlayer (bosh-lite)"
+bosh create-env bosh.yml \
+  -o jumpbox-user.yml \
+  -o softlayer/cpi-dynamic.yml \
+  -o bosh-lite.yml \
+  -o bosh-lite-runc.yml \
+  -o softlayer/add-sl-domain-to-lite-director.yml \
+  --vars-store  $(mktemp ${tmp_file}.XXXXXX) \
+  -v director_name=bosh-lite \
+  -v sl_vm_name_prefix=bosh-lite \
+  -v sl_vm_domain=test \
+  -v sl_username=user \
+  -v sl_api_key=api-key \
+  -v sl_datacenter=dc \
+  -v sl_vlan_public=12345 \
+  -v sl_vlan_private=54321 \
+  -v internal_ip=bosh-lite.test
+
 echo "- Warden"
 bosh create-env bosh.yml \
   -o warden/cpi.yml \


### PR DESCRIPTION
This commit adds an OPS file which will map the director IP
with the internal Softlayer domain in the director /etc/hosts file.
This is requirement for accessing (ssh) bosh-lite components using socks5 proxy.

Signed-off-by: Norman Sutorius <norman.sutorius@de.ibm.com>