### PR TITLE
Remove uaa port

### DIFF
--- a/uaa.yml
+++ b/uaa.yml
@@ -31,7 +31,6 @@
     properties:
       uaa:
         url: "https://((internal_ip)):8443"
-        port: -1
         sslPrivateKey: ((uaa_ssl.private_key))
         sslCertificate: ((uaa_ssl.certificate))
         jwt:


### PR DESCRIPTION
Setting the port to -1 is breaking the latest UAA release: https://github.com/cloudfoundry/uaa-release/commit/7a0462d05237a501a9a2d102556606286d120687#diff-8692c40f7c79b6642193a423aa7bee49

It gets interpolated into the monitrc file and causes monit to fail:
```
bosh/0:~# monit summary
/var/vcap/monit/job/0004_uaa.monitrc:7: Error: syntax error '-1'
```

@mdelillo @kardolus 