### PR TITLE
Fix invalid CA reference for blobstore TLS

### DIFF
--- a/experimental/blobstore-https.yml
+++ b/experimental/blobstore-https.yml
@@ -3,7 +3,7 @@
 - type: replace
   path: /instance_groups/name=bosh/properties/blobstore/tls?/cert
   value:
-    ca: ((blobstore_ca_cert.ca))
+    ca: ((blobstore_ssl.ca))
     certificate: ((blobstore_ssl.certificate))
     private_key: ((blobstore_ssl.private_key))
 


### PR DESCRIPTION
Not sure how and why this could work before. I guess it should either have been `blobstore_ca_cert` or `blobstore_ssl.ca`.