### PR TITLE
Add default-disk-type.yml operations file for vSphere CPI.

### DIFF
--- a/vsphere/default-disk-type.yml
+++ b/vsphere/default-disk-type.yml
@@ -1,0 +1,5 @@
+---
+# set default disk type - either 'thin' or 'preallocated' must be provided
+- type: replace
+  path: /instance_groups/name=bosh/properties/vcenter/default_disk_type?
+  value: ((vcenter_default_disk_type))


### PR DESCRIPTION
Added an operations file allowing operators to select which disk type should be the default in BOSH director.
Either 'thin' or 'preallocated' can be provided.  https://bosh.io/docs/vsphere-cpi/#global