### PR TITLE
Update google cpi release to 27.0.1

### DIFF
--- a/gcp/cpi.yml
+++ b/gcp/cpi.yml
@@ -3,9 +3,9 @@
   path: /releases/-
   value:
     name: bosh-google-cpi
-    version: "27.0.0"
-    url: https://bosh.io/d/github.com/cloudfoundry-incubator/bosh-google-cpi-release?v=27.0.0
-    sha1: cbbf73c102b1f27d3db15d95bc971b2b4995c78e
+    version: "27.0.1"
+    url: https://bosh.io/d/github.com/cloudfoundry-incubator/bosh-google-cpi-release?v=27.0.1
+    sha1: 1cd4e89aa2ba7479ad65a68ae520d104590a2c5b
 
 - type: replace
   path: /resource_pools/name=vms/stemcell?


### PR DESCRIPTION
The 27.0.1 release contains improved retry logic for oauth requests, which should help with this issue: https://github.com/cloudfoundry-incubator/bosh-google-cpi-release/issues/268