### PR TITLE
Add miscelaneous ops-file for uncompiled releases

### DIFF
--- a/misc/source-releases/bosh.yml
+++ b/misc/source-releases/bosh.yml
@@ -1,0 +1,16 @@
+---
+- type: replace
+  path: /releases/name=bosh?
+  value:
+    name: "bosh"
+    version: "266.2.0"
+    url: "https://bosh.io/d/github.com/cloudfoundry/bosh?v=266.2.0"
+    sha1: "e181568c96858139391abf56fe068d56b10140cf"
+
+- type: replace
+  path: /releases/name=bpm?
+  value:
+    name: "bpm"
+    version: "0.6.0"
+    url: "https://bosh.io/d/github.com/cloudfoundry-incubator/bpm-release?v=0.6.0"
+    sha1: "4f0f239abdc801d71de9063625aa56e3c42634b5"


### PR DESCRIPTION
Using compiled bits for trusty on different stemcells is not guaranteed
to work. This change provides an opsfile to use uncompiled releases from
bosh-io to force the deploy to recompile the release.

Co-authored-by: James Myers <jmyers@pivotal.io>