### PR TITLE
Add ops file to enable TLS communication with registry db

### DIFF
--- a/experimental/registry-db-enable-tls.yml
+++ b/experimental/registry-db-enable-tls.yml
@@ -1,0 +1,6 @@
+- type: replace
+  path: /instance_groups/name=bosh/properties/registry/db/tls?
+  value:
+    enabled: true
+    cert:
+      ca: ((db_ca))


### PR DESCRIPTION
Hi BOSH friends,

We were enabling TLS for both the director db and the registry db, and noticed that the ops file was missing for registry. We checked to make sure that this is supported, and it looks like the necessary properties are available: https://github.com/cloudfoundry/bosh/blob/master/jobs/registry/spec#L65-L69

Tracker story in our backlog, if it's useful: https://www.pivotaltracker.com/story/show/157613913

Thanks!

Raina and Renee
CF Cloud Ops