### PR TITLE
Replace deprecated uaa saml properties.

### DIFF
--- a/uaa.yml
+++ b/uaa.yml
@@ -40,8 +40,11 @@
         sslPrivateKey: ((uaa_ssl.private_key))
         sslCertificate: ((uaa_ssl.certificate))
         jwt:
-          signing_key: ((uaa_jwt_signing_key.private_key))
-          verification_key: ((uaa_jwt_signing_key.public_key))
+          policy:
+            active_key_id: uaa-jwt-key-1
+            keys:
+              uaa-jwt-key-1:
+                signingKey: ((uaa_jwt_signing_key.private_key))
         scim:
           users:
           - name: admin

--- a/uaa.yml
+++ b/uaa.yml
@@ -78,9 +78,12 @@
         zones: {internal: {hostnames: []}}
       login:
         saml:
-          serviceProviderKey: ((uaa_service_provider_ssl.private_key))
-          serviceProviderKeyPassword: "" # TODO: Remove this when UAA defaults this value
-          serviceProviderCertificate: ((uaa_service_provider_ssl.certificate))
+          activeKeyId: uaa-saml-key-1
+          keys:
+            uaa-saml-key-1:
+              key: ((uaa_service_provider_ssl.private_key))
+              certificate: ((uaa_service_provider_ssl.certificate))
+              passphrase: ""
       uaadb:
         address: 127.0.0.1
         port: 5432


### PR DESCRIPTION
The `login.saml.serviceProviderKey` and
`login.saml.serviceProviderCertificate` parameters are deprecated:
https://github.com/cloudfoundry/uaa-release/blob/develop/jobs/uaa/spec#L1099-L1148.
This patch replaces the deprecated saml properties with
`login.saml.keys`.

cc @cppforlife @dpb587-pivotal 