### PR TITLE
Update bosh_cli scope for teams

### DIFF
--- a/uaa.yml
+++ b/uaa.yml
@@ -51,7 +51,7 @@
           bosh_cli:
             override: true
             authorized-grant-types: password,refresh_token
-            scope: openid,bosh.admin,bosh.read,bosh.*.admin,bosh.*.read
+            scope: openid,bosh.admin,bosh.read,bosh.*.admin,bosh.*.read,bosh.teams.*.admin,bosh.teams.*.read
             authorities: uaa.none
             access-token-validity: 120 # 2 min
             refresh-token-validity: 86400 # 1 day


### PR DESCRIPTION
It looks like the UAA wildcard scopes are single-level only,
so adding the bosh.teams.*.<read|admin> to get the cli to properly
request user authorities when using bosh teams with external users
+ external group mappings.

Signed-off-by: David Bishop <dbisj@allstate.com>