### PR TITLE
Explicitly declare UAA groups with descriptions

### DIFF
--- a/uaa.yml
+++ b/uaa.yml
@@ -43,6 +43,11 @@
           signing_key: ((uaa_jwt_signing_key.private_key))
           verification_key: ((uaa_jwt_signing_key.public_key))
         scim:
+          groups:
+            bosh.admin: 'User has admin access on any Director'
+            bosh.read: 'User has read access on any Director'
+            bosh.stemcells.upload: 'User can upload new stemcells'
+            bosh.releases.upload: 'User can upload new releases'
           users:
           - name: admin
             groups: [bosh.admin]


### PR DESCRIPTION
Operators will be able to discover groups via `uaa groups`/UAA API:

```
$ uaa groups | jq -cr "map({displayName, description})[]" | grep bosh
{"displayName":"bosh.releases.upload","description":"User can upload new releases"}
{"displayName":"bosh.stemcells.upload","description":"User can upload new stemcells"}
{"displayName":"bosh.read","description":"User has read access on any Director"}
{"displayName":"bosh.admin","description":"User has admin access on any Director"}
```