### PR TITLE
explicit set of scoped authorities for each UAA user created

### DIFF
--- a/uaa.yml
+++ b/uaa.yml
@@ -42,6 +42,13 @@
         jwt:
           signing_key: ((uaa_jwt_signing_key.private_key))
           verification_key: ((uaa_jwt_signing_key.public_key))
+        user:
+          authorities:
+          - bosh.admin          # admin access to all BOSH directors
+          - openid              # User identity from OpenID Connect
+          - scim.me             # read/query access current user's account
+          - password.write      # can update own password
+          - uaa.user            # allows authentication as a user
         scim:
           groups:
             bosh.admin: 'User has admin access on any Director'


### PR DESCRIPTION
Currently, the uaa-release allocates a smorgasbord of default authorities to each new UAA user - with the apparent assumption all UAA users want to do something with Cloud Foundry (e.g. `cloud_controller.read` and `notification_preferences.read`).

https://github.com/cloudfoundry/uaa-release/blob/3507982674a6a74c0c738e21ccdb34ddb67a8469/jobs/uaa/spec#L569-L586

This PR scopes it down to the set I believe are required for BOSH UAA users - via the `bosh` itself or for its own interactions with `uaa` CLI (e.g. update their password).

Example:

```
uaa create-user drnic \
  --password drnic_secret \
  --email drnic@starkandwayne.com \
  --givenName "Dr Nic" \
  --familyName "Williams"
```

The output shows the smaller limited set of useful UAA authorities that `drnic` is initially assigned:

```json
{
  "id": "226df59f-ceea-48dc-832e-c1cbfcecd794",
  "meta": {
    "created": "2018-07-07T06:45:25.345Z",
    "lastModified": "2018-07-07T06:45:25.345Z"
  },
  "userName": "drnic",
  "name": {
    "familyName": "Williams",
    "givenName": "Dr Nic"
  },
  "emails": [
    {
      "value": "drnic@starkandwayne.com",
      "primary": false
    }
  ],
  "groups": [
    {
      "value": "09a699a2-84ad-4734-bb66-10ca788925fc",
      "display": "scim.me",
      "type": "DIRECT"
    },
    {
      "value": "ef2ddeb4-d5b1-4c20-b3de-ce225e4efab9",
      "display": "password.write",
      "type": "DIRECT"
    },
    {
      "value": "abd2bec1-2d53-45fe-8141-f2138982fb30",
      "display": "openid",
      "type": "DIRECT"
    },
    {
      "value": "f9f5fe25-78ed-4437-8f81-e6f8642be71d",
      "display": "bosh.admin",
      "type": "DIRECT"
    },
    {
      "value": "dcc81daf-1af5-4b1e-8796-f0bb9fdb582e",
      "display": "uaa.user",
      "type": "DIRECT"
    }
  ],
  "active": true,
  "verified": true,
  "origin": "uaa",
  "zoneId": "uaa",
  "passwordLastModified": "2018-07-07T06:45:25.000Z",
  "schemas": [
    "urn:scim:schemas:core:1.0"
  ]
}
```

After `bosh login`, my `drnic` user has the appropriately filtered scopes required for normal BOSH operations:

```
$ bosh env
Using environment '192.168.50.6' as user 'drnic' (openid, bosh.admin)

Name      bucc
UUID      3e275b31-f71d-48ac-b9ce-3fb3d1d13060
Version   265.2.0 (00000000)
CPI       warden_cpi
Features  compiled_package_cache: disabled
          config_server: enabled
          dns: disabled
          snapshots: disabled
User      drnic
```