### PR TITLE
Add ops files for native CPI disk resizing and OpenStack nova networking

### DIFF
--- a/misc/cpi-resize-disk.yml
+++ b/misc/cpi-resize-disk.yml
@@ -1,0 +1,4 @@
+---
+- type: replace
+  path: /instance_groups/name=bosh/properties/director/enable_cpi_resize_disk?
+  value: true

--- a/openstack/nova-networking.yml
+++ b/openstack/nova-networking.yml
@@ -1,0 +1,4 @@
+---
+- type: replace
+  path: /instance_groups/name=bosh/properties/openstack/use_nova_networking?
+  value: true


### PR DESCRIPTION
Add ops files for

- native CPI disk resizing
- using OpenStack nova networking instead of neutron networking

[#156910949](https://www.pivotaltracker.com/story/show/156910949)