### PR TITLE
Update credhub.yml to be compatible with newer version of CredHub

### DIFF
--- a/credhub.yml
+++ b/credhub.yml
@@ -13,6 +13,9 @@
     release: credhub
     properties:
       credhub:
+        authorization:
+          acls:
+            enabled: false
         authentication:
           uaa:
             url: "https://((internal_ip)):8443"

--- a/credhub.yml
+++ b/credhub.yml
@@ -34,7 +34,8 @@
             type: internal
           keys:
           - provider_name: internal
-            encryption_password: ((credhub_encryption_password))
+            key_properties:
+              encryption_password: ((credhub_encryption_password))
             active: true
 
 - type: replace


### PR DESCRIPTION
In the upcoming 2.0 version of CredHub, ACLs will be enabled by default. Bosh needs ACLs to be disabled. We have moved some of the encryption properties in a nested key_properties block. 