### PR TITLE
Added resource pool support

### DIFF
--- a/vsphere/cpi.yml
+++ b/vsphere/cpi.yml
@@ -54,7 +54,8 @@
       persistent_datastore_pattern: ((vcenter_ds))
       disk_path: ((vcenter_disks))
       clusters:
-      - ((vcenter_cluster)): {}
+      - ((vcenter_cluster)):
+        resource_pool: ((vcenter_rp))
 
 - type: replace
   path: /cloud_provider/properties/vcenter?


### PR DESCRIPTION
As per [CPI Documentation](https://bosh.io/docs/init-vsphere/) there is an optional configuration parameter`vcenter_rp` to specify target resource pool.
However, this parameter has not been used in `cpi.yml` yet. As a result, custom resource pools was not actually supported. 
This PR fixes that.