### PR TITLE
Add operator for no internet os-conf

### DIFF
--- a/misc/no-internet-access/os_conf.yml
+++ b/misc/no-internet-access/os_conf.yml
@@ -1,0 +1,10 @@
+- type: replace
+  path: /releases/name=os-conf/url
+  value: file://((local_os_conf_release))
+
+- type: remove
+  path: /releases/name=os-conf/sha1
+
+- type: replace
+  path: /releases/name=os-conf/version
+  value: latest


### PR DESCRIPTION
Adds an operator for  offline deployments that want to use os_conf for a jumpbox user.