### PR TITLE
Fix Xenial-compiled release `- releases[0].name must be provided`

### DIFF
--- a/experimental/xenial-compiled-releases.yml
+++ b/experimental/xenial-compiled-releases.yml
@@ -2,6 +2,7 @@
 - type: replace
   path: /releases/name=bosh?
   value:
+    name: bosh
     version: "267.5.0"
     url: https://s3.amazonaws.com/bosh-compiled-release-tarballs/bosh-267.5.0-ubuntu-xenial-97.12-20180820-234355-048784588-20180820234358.tgz?versionId=X168wrj6izNJTi0V0bSPNpeKl_kZeahW
     sha1: 37499312e1186237434ee7a2492812b084c4e345
@@ -9,6 +10,7 @@
 - type: replace
   path: /releases/name=bpm?
   value:
+    name: bpm
     version: "0.11.0"
     url: https://s3.amazonaws.com/bosh-compiled-release-tarballs/bpm-0.11.0-ubuntu-xenial-97.12-20180820-235033-474094256-20180820235039.tgz?versionId=hzs0XSVxZzPFsTPDY3c3trwPf0OtugqB
     sha1: 6008b48192ac38ce6ac6ff23ea5029ac2b5bc2b9
@@ -16,6 +18,7 @@
 - type: replace
   path: /releases/name=credhub?
   value:
+    name: credhub
     version: "1.9.3"
     url: https://s3.amazonaws.com/bosh-compiled-release-tarballs/credhub-1.9.3-ubuntu-xenial-97.12-20180815-230755-343182304-20180815230804.tgz?versionId=jhFK3zlmI.eqpOkz_YrRzXwoTeDAXmMd
     sha1: 7703e7a0517e02ec736c1e89a73700aa4ca9ae87
@@ -23,6 +26,7 @@
 - type: replace
   path: /releases/name=uaa?
   value:
+    name: uaa
     version: "60.2"
     url: https://s3.amazonaws.com/bosh-compiled-release-tarballs/uaa-60.2-ubuntu-xenial-97.12-20180815-231707-188963409-20180815231720.tgz?versionId=AJarW.I0RXfMpEAgq.d.qCuG_oAht_80
     sha1: 97fcf9ce8b8bc9866771ce4c1ba59c9b19aa6f25
@@ -30,6 +34,7 @@
 - type: replace
   path: /releases/name=backup-and-restore-sdk?
   value:
+    name: backup-and-restore-sdk
     version: "1.9.0"
     url: https://s3.amazonaws.com/bosh-compiled-release-tarballs/backup-and-restore-sdk-1.9.0-ubuntu-xenial-97.12-20180815-231632-167459407-20180815231656.tgz?versionId=vXg0sHpm_5ZP8FP7WkNbKMaK5sYAEyrc
     sha1: 56d8644ee362531d3242f9f64ca95604d77d5f72


### PR DESCRIPTION
The `experimental/xenial-compiled-releases.yml` manifest operations file updates the BOSH releases to Xenial-compiled versions, but drops the release name, which causes the deployment to fail.

[Here](https://github.com/cunnie/deployments/blob/271cc5ed427d99fbe9bc48b6a9df61d7eda6e408/bosh-aws.yml#L1552-L1555) is an example of a BOSH manifest missing the BOSH release name.

fixes <https://ci.nono.io/teams/main/pipelines/BOSH/jobs/bosh-aws.nono.io/builds/44>:
```
Parsing release set manifest '/tmp/build/b0d51b9f/cunnie-deployments/bosh-aws.yml':
  Validating release set manifest:
    - releases[0].name must be provided
    - releases[1].name must be provided
    - releases[1].name '' must be unique
    - releases[4].name must be provided
    - releases[4].name '' must be unique
    - releases[5].name must be provided
    - releases[5].name '' must be unique
    - releases[6].name must be provided
    - releases[6].name '' must be unique
```

Here is the URL of a successful AWS deploy: https://ci.nono.io/teams/main/pipelines/BOSH/jobs/bosh-aws.nono.io/builds/45. I've also successfully deployed (with this change) to Azure, Google, and vSphere.