### PR TITLE
Add a credhub-cli user to uaa

### DIFF
--- a/credhub.yml
+++ b/credhub.yml
@@ -91,10 +91,26 @@
     secret: ((credhub_admin_client_secret))
 
 - type: replace
+  path: /instance_groups/name=bosh/jobs/name=uaa/properties/uaa/scim/users/name=credhub_cli_user?/password
+  value: ((credhub_cli_user_password))
+
+- type: replace
+  path: /instance_groups/name=bosh/jobs/name=uaa/properties/uaa/scim/users/name=credhub_cli_user?/groups
+  value:
+    - credhub.read
+    - credhub.write
+
+- type: replace
   path: /instance_groups/name=bosh/jobs/name=uaa/properties/uaa/jwt/revocable?
   value: true
 
 # Variables
+- type: replace
+  path: /variables/-
+  value:
+    name: credhub_cli_user_password
+    type: password
+
 - type: replace
   path: /variables/-
   value:


### PR DESCRIPTION
- CredHub users want to be able to login to CredHub
  interactively so that the client credentials are not
  exposed in plaintext anywhere. Previously CredHub users
  were using the credhub-cli client to login, which meant the
  client secret had to be exposed in plaintext either in the
  environment or as a value passed to the login command.

Signed-off-by: Anna Thornton <athornton@pivotal.io>