### PR TITLE
DataDog metrics are tagged with director name

### DIFF
--- a/hm/datadog.yml
+++ b/hm/datadog.yml
@@ -4,6 +4,8 @@
   value:
     api_key: ((datadog_api_key))
     application_key: ((datadog_application_key))
+    custom_tags:
+      director: ((director_name))
 
 - type: replace
   path: /instance_groups/name=bosh/properties/hm/datadog_enabled?


### PR DESCRIPTION
Follow-up to https://github.com/cloudfoundry/bosh/pull/2077

### Background

DataDog allows tags to be attached to metrics. BOSH healthmonitor attaches some tags, e.g. the deployment that originated the metric. This is great.

But if you've got multiple directors, each with similar-looking deployments, all forwarding metrics to the same DataDog account, then all those metrics get mixed together: There isn't a straightforward way to distinguish metrics based on the originating director. So, for example, it is tough to make a dashboard showing metrics from only one director, or to compare the same metrics across different directors.

### This change

This change will cause all metrics from a director to be tagged with the director name.

This way, you can distinguish between those directors in your datadog dashboards.

[Related story that could take advantage of this feature](https://www.pivotaltracker.com/story/show/161104272)