### PR TITLE
Add stemcell OS and version to compiled releases

### DIFF
--- a/bosh.yml
+++ b/bosh.yml
@@ -6,10 +6,16 @@ releases:
   version: "268.3.0"
   url: https://s3.amazonaws.com/bosh-compiled-release-tarballs/bosh-268.3.0-ubuntu-xenial-170.9-20181126-235012-624865282-20181126235018.tgz
   sha1: 55db35a445d93eb263a2feeec2bc88cbbd8ffe33
+  stemcell:
+    os: ubuntu-xenial
+    version: "170.9"
 - name: bpm
   version: "0.12.3"
   url: https://s3.amazonaws.com/bosh-compiled-release-tarballs/bpm-0.12.3-ubuntu-xenial-170.9-20181126-234429-76772131-20181126234436.tgz
   sha1: 1cc709f4be6fb2ec7ea3205d81ecad7039a979b4
+  stemcell:
+    os: ubuntu-xenial
+    version: "170.9"
 
 resource_pools:
 - name: vms

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -213,9 +213,13 @@ jobs:
       - get: bosh-deployment
       - get: compiled-bosh-release
         trigger: true
+      - get: ubuntu-xenial-stemcell
     - task: update-bosh-deployment
       file: bosh-deployment/ci/tasks/use-latest-release.yml
+      input_mapping:
+        stemcell: ubuntu-xenial-stemcell
       params:
+        STEMCELL_OS: ubuntu-xenial
         RELEASE_NAME: bosh
     - put: bosh-deployment
       params:

--- a/ci/tasks/use-latest-release.sh
+++ b/ci/tasks/use-latest-release.sh
@@ -5,6 +5,7 @@ tar -xzf compiled-bosh-release/*.tgz $( tar -tzf *.tgz | grep 'release.MF' )
 VERSION=$( grep -E '^version: ' release.MF | awk '{print $2}' | tr -d "\"'" )
 URL=$(cat compiled-bosh-release/url)
 SHA1=$(sha1sum compiled-bosh-release/*.tgz | awk '{print $1}')
+STEMCELL_VERSION=$( cat stemcell/version )
 
 INTERPOLATE_SCRIPT=interpolate_script.rb
 MANIFEST=bosh-deployment-output/bosh.yml
@@ -21,6 +22,9 @@ lines.each_with_index do |line, i|
     lines[i+1] = "  version: \"$VERSION\"\n"
     lines[i+2] = "  url: $URL\n"
     lines[i+3] = "  sha1: $SHA1\n"
+    lines[i+4] = "  stemcell:\n"
+    lines[i+5] = "    os: #{ENV['STEMCELL_OS']}\n"
+    lines[i+6] = "    version: $STEMCELL_VERSION\n"
     break
   end
 end

--- a/ci/tasks/use-latest-release.yml
+++ b/ci/tasks/use-latest-release.yml
@@ -14,6 +14,7 @@ outputs:
   - name: bosh-deployment-output
 
 params:
+  STEMCELL_OS: replace-me
   RELEASE_NAME: replace-me
 
 run:

--- a/credhub.yml
+++ b/credhub.yml
@@ -5,6 +5,9 @@
     version: "2.0.2"
     url: https://s3.amazonaws.com/bosh-compiled-release-tarballs/credhub-2.0.2-ubuntu-xenial-170.9-20181126-235205-877343813-20181126235215.tgz
     sha1: c1759ba08a927cd8b4476baefe5f803cbb95d515
+    stemcell:
+      os: ubuntu-xenial
+      version: "170.9"
 
 - type: replace
   path: /instance_groups/name=bosh/jobs/-

--- a/misc/bosh-dev.yml
+++ b/misc/bosh-dev.yml
@@ -31,7 +31,7 @@
   value:
     alias: default
     os: ubuntu-xenial
-    version: "97.12"
+    version: "170.9"
 
 - type: replace
   path: /instance_groups/name=bosh/stemcell?

--- a/uaa.yml
+++ b/uaa.yml
@@ -5,6 +5,9 @@
     version: "64.0"
     url: https://s3.amazonaws.com/bosh-compiled-release-tarballs/uaa-64.0-ubuntu-xenial-170.9-20181126-235054-308376184-20181126235108.tgz
     sha1: e788ee7c1fce8ab9447e3772e54e11a2d69d475a
+    stemcell:
+      os: ubuntu-xenial
+      version: "170.9"
 
 # Switch Director to use UAA
 - type: replace


### PR DESCRIPTION
Supporting the use-case of just updating the stemcell without updating
the release. Otherwise, uploading the compiled release will not happen,
because the director just checks for name and version in its DB.