### PR TITLE
Add custom-ca ops file for vsphere

### DIFF
--- a/vsphere/custom-ca.yml
+++ b/vsphere/custom-ca.yml
@@ -1,0 +1,10 @@
+---
+- type: replace
+  path: /instance_groups/name=bosh/properties/vcenter/connection_options?
+  value:
+    ca_cert: ((vcenter_ca_cert))
+
+- type: replace
+  path: /cloud_provider/properties/vcenter/connection_options?
+  value:
+    ca_cert: ((vcenter_ca_cert))


### PR DESCRIPTION
custom-ca.yml added in similar manner to those already available for openstack here: https://github.com/cloudfoundry/bosh-deployment/blob/master/openstack/custom-ca.yml

For a vanilla install of vcenter 6.5 you would just add your root cert which can be downloaded as described here: http://www.techazine.com/2017/09/22/an-easy-fix-for-vsphere-6-5-web-client-and-certificates-to-keep-your-uploads-flowing/