### PR TITLE
Add ops files for external UAA and Credhub Databases

### DIFF
--- a/misc/external-db-credhub.yml
+++ b/misc/external-db-credhub.yml
@@ -1,3 +1,5 @@
+#This ops file requires that you applied the credhub.yml ops file first
+---
 - type: replace
   path: /instance_groups/name=bosh/jobs/name=credhub/properties/credhub/data_storage
   value:

--- a/misc/external-db-credhub.yml
+++ b/misc/external-db-credhub.yml
@@ -1,0 +1,10 @@
+- type: replace
+  path: /instance_groups/name=bosh/jobs/name=credhub/properties/credhub/data_storage
+  value:
+    host: ((external_db_host_credhub))
+    port: ((external_db_port_credhub))
+    database: ((external_db_name_credhub))
+    username: ((external_db_user_credhub))
+    password: ((external_db_password_credhub))
+    require_tls: ((external_db_require_tls_credhub))
+    type: ((external_db_adapter_credhub))

--- a/misc/external-db-uaa.yml
+++ b/misc/external-db-uaa.yml
@@ -1,4 +1,5 @@
-
+#This ops file requires that you used the uaa.yml ops file first
+---
 - type: replace
   path: /instance_groups/name=bosh/jobs/name=uaa/properties/uaadb
   value:

--- a/misc/external-db-uaa.yml
+++ b/misc/external-db-uaa.yml
@@ -1,0 +1,14 @@
+
+- type: replace
+  path: /instance_groups/name=bosh/jobs/name=uaa/properties/uaadb
+  value:
+    address: ((external_db_host_uaa))
+    port: ((external_db_port_uaa))
+    databases:
+      - name: ((external_db_name_uaa))
+        tag: uaa
+    roles:
+      - name: ((external_db_user_uaa))
+        password: ((external_db_password_uaa))
+        tag: admin
+    db_scheme: ((external_db_scheme_uaa))

--- a/tests/run-checks.sh
+++ b/tests/run-checks.sh
@@ -151,6 +151,49 @@ bosh create-env bosh.yml \
   -v external_db_adapter=test \
   -v external_db_name=test
 
+echo "- AWS with UAA + CredHub + External dbs for all"
+bosh create-env bosh.yml \
+  -o aws/cpi.yml \
+  -o uaa.yml \
+  -o credhub.yml \
+  -o misc/external-db.yml \
+  -o misc/external-db-uaa.yml \
+  -o misc/external-db-credhub.yml \
+  --state=$tmp_file \
+  --vars-store $(mktemp ${tmp_file}.XXXXXX) \
+  -v director_name=test \
+  -v internal_cidr=test \
+  -v internal_gw=test \
+  -v internal_ip=test \
+  -v access_key_id=test \
+  -v secret_access_key=test \
+  -v az=test \
+  -v region=test \
+  -v default_key_name=test \
+  -v default_security_groups=[test] \
+  -v private_key=test \
+  -v subnet_id=test \
+  -v credhub_encryption_password=test \
+  -v external_db_host=test \
+  -v external_db_port=test \
+  -v external_db_user=test \
+  -v external_db_password=test \
+  -v external_db_adapter=test \
+  -v external_db_name=test \
+  -v external_db_host_credhub=test \
+  -v external_db_port_credhub=test \
+  -v external_db_name_credhub=test \
+  -v external_db_user_credhub=test \
+  -v external_db_password_credhub=test \
+  -v external_db_require_tls_credhub=test \
+  -v external_db_adapter_credhub=test \
+  -v external_db_host_uaa=test \
+  -v external_db_port_uaa=test \
+  -v external_db_user_uaa=test \
+  -v external_db_name_uaa=test \
+  -v external_db_password_uaa=test \
+  -v external_db_scheme_uaa=test 
+
 echo "- AWS (cloud-config)"
 bosh update-cloud-config aws/cloud-config.yml \
   -v internal_cidr=test \


### PR DESCRIPTION
We have been using those ops files for a while and we think that it might be a good idea to move them over to the Base repository to make them more accessible.

(Might also deliver the feature requested here: https://github.com/cloudfoundry/bosh-deployment/issues/229)