### PR TITLE
Bump vSphere CPI 51 → 52

### DIFF
--- a/vsphere/cpi.yml
+++ b/vsphere/cpi.yml
@@ -3,9 +3,9 @@
   path: /releases/-
   value:
     name: bosh-vsphere-cpi
-    version: "51"
-    url: https://bosh.io/d/github.com/cloudfoundry/bosh-vsphere-cpi-release?v=51
-    sha1: 99fc5ad16d6f43727d6191220918bace38bdb0ed
+    version: "52"
+    url: https://bosh.io/d/github.com/cloudfoundry/bosh-vsphere-cpi-release?v=52
+    sha1: 73f4cd14eef75e037d6ca553ee63d8b55062f0ab
 
 - type: replace
   path: /resource_pools/name=vms/stemcell?


### PR DESCRIPTION
From <https://github.com/cloudfoundry/bosh-vsphere-cpi-release/releases/tag/v52>:

> Added support for HostGroups as a new type of AZ in the CPI. You can now
add Host groups as a part of your AZ along with Resource pools and
clusters.

Example Cloud Config:
```yaml
azs:
 -name: z1
  cloud_properties:
    datacenters:
    - clusters:
      - vcpi-cluster-1: {host_group: 'vcpi-cl1-hg-1'}
 -name: z2
  cloud_properties:
    datacenters:
    - clusters:
      - vcpi-cluster-2: {host_group: 'vcpi-cl2-hg-1'}
```