### PR TITLE
Bump Google CPI 27.0.1 → 29.0.0

### DIFF
--- a/gcp/cpi.yml
+++ b/gcp/cpi.yml
@@ -3,9 +3,9 @@
   path: /releases/-
   value:
     name: bosh-google-cpi
-    version: "27.0.1"
-    url: https://bosh.io/d/github.com/cloudfoundry/bosh-google-cpi-release?v=27.0.1
-    sha1: 911a48764dbb24c50aedd4e3095d1603d385e135
+    version: "29.0.0"
+    url: https://bosh.io/d/github.com/cloudfoundry/bosh-google-cpi-release?v=29.0.0
+    sha1: ab8e434c6cc86eb130d30f361d210126d5a539bd
 
 - type: replace
   path: /resource_pools/name=vms/stemcell?


### PR DESCRIPTION
From
<https://github.com/cloudfoundry/bosh-google-cpi-release/releases/tag/v29.0.0>:

Fixed:

- VM IP address is cleared when dynamic network is used

Added:

- Logs are returned in response to BOSH, making them viewable in task log
- If a disk is already attached to a VM, it will only be attached via the BOSH agent