### PR TITLE
Allow bosh-dns to run on windows 2019 stemcells

### DIFF
--- a/runtime-configs/dns.yml
+++ b/runtime-configs/dns.yml
@@ -50,6 +50,7 @@ addons:
     - os: windows2012R2
     - os: windows2016
     - os: windows1803
+    - os: windows2019
 
 variables:
 - name: /dns_healthcheck_tls_ca


### PR DESCRIPTION
Previous https://github.com/cloudfoundry/bosh-deployment/pull/293

cc @sophiewigmore