### PR TITLE
upgrade credhub to 2.1.x line

### DIFF
--- a/credhub.yml
+++ b/credhub.yml
@@ -2,10 +2,10 @@
   release: credhub
   type: replace
   value:
-    name: credhub
-    sha1: 44da436b4c60b7dae04fb151d9b231f762e58da4
-    url: https://s3.amazonaws.com/bosh-compiled-release-tarballs/credhub-2.0.2-ubuntu-xenial-250.9-20190215-221127-182336832-20190215221137.tgz
-    version: 2.0.2
+    name: "credhub"
+    version: "2.1.2"
+    url: "https://bosh.io/d/github.com/pivotal-cf/credhub-release?v=2.1.2"
+    sha1: "754a24dbffe8bc5efce7e698d935b5f4df541f38"
 - path: /instance_groups/name=bosh/jobs/-
   type: replace
   value:


### PR DESCRIPTION
- credhub 2.0.x is not in support and should not be used

- we tested this and confirmed it works

Signed-off-by: Josh Zarrabi <jzarrabi@pivotal.io>