### PR TITLE
increase the ephemeral disk on the vSphere compilation vm

### DIFF
--- a/vsphere/cloud-config.yml
+++ b/vsphere/cloud-config.yml
@@ -17,7 +17,7 @@ vm_types:
   cloud_properties:
     cpu: 2
     ram: 1024
-    disk: 3240
+    disk: 30_000
 - name: large
   cloud_properties:
     cpu: 2


### PR DESCRIPTION
A compilation VM with only 3GB of disk is insufficiently small for the Concourse 5.0 bosh release.

I imagine there are probably other bosh releases that fail to compile due to insufficient disk space.