### PR TITLE
Bump uaa source release to 64.0

### DIFF
--- a/misc/source-releases/uaa.yml
+++ b/misc/source-releases/uaa.yml
@@ -3,6 +3,6 @@
   path: /releases/name=uaa?
   value:
     name: uaa
-    version: "60.2"
-    url: https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=60.2
-    sha1: 667af417997467681fddf13c78e5a11c6f4a9d15
+    version: "64.0"
+    url: https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=64.0
+    sha1: f10caefdd136675975bfc88d6409f322c68209d4


### PR DESCRIPTION
Keeping it aligned to [uaa.yml](https://github.com/cloudfoundry/bosh-deployment/blob/master/uaa.yml)

Co-authored-by: Florian Nachtigall florian.nachtigall@sap.com