### PR TITLE
Pass command-line args to create-env

### DIFF
--- a/virtualbox/create-env.sh
+++ b/virtualbox/create-env.sh
@@ -32,7 +32,7 @@ bosh create-env "${bosh_deployment}/bosh.yml" \
   --var internal_ip=192.168.50.6 \
   --var internal_gw=192.168.50.1 \
   --var internal_cidr=192.168.50.0/24 \
-  --var outbound_network_name=NatNetwork
+  --var outbound_network_name=NatNetwork "$@"
 
 
 ####


### PR DESCRIPTION
add additional ops-files or flags like --recreate on the fly.

Co-authored-by: Manuel Dewald <m.dewald@sap.com>