### PR TITLE
Bump vSphere CPI 52 → 52.1.1

### DIFF
--- a/bosh.yml
+++ b/bosh.yml
@@ -150,9 +150,9 @@ releases:
   url: https://s3.amazonaws.com/bosh-compiled-release-tarballs/bosh-270.1.1-ubuntu-xenial-315.34-20190529-170358-910341791-20190529170407.tgz
   version: 270.1.1
 - name: bpm
-  sha1: 3ed31e60462164509df7fcd4d5791fa14e03cda2
-  url: https://s3.amazonaws.com/bosh-compiled-release-tarballs/bpm-1.0.4-ubuntu-xenial-315.26-20190517-195714-698683942-20190517195721.tgz
-  version: 1.0.4
+  sha1: 24ded7bf449ecfb598e257ed32f5197c39fd0d07
+  url: https://s3.amazonaws.com/bosh-compiled-release-tarballs/bpm-1.1.0-ubuntu-xenial-315.34-20190531-003303-006902624-20190531003309.tgz
+  version: 1.1.0
 resource_pools:
 - env:
     bosh:

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -578,7 +578,7 @@ resources:
 - name: bpm-release
   type: bosh-io-release
   source:
-    repository: cloudfoundry-incubator/bpm-release
+    repository: cloudfoundry/bpm-release
 
 - name: credhub-release
   type: bosh-io-release

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -165,7 +165,7 @@ jobs:
         input_mapping:
           release: bpm-release
         params:
-          BOSH_IO_RELEASE: cloudfoundry-incubator/bpm-release
+          BOSH_IO_RELEASE: cloudfoundry/bpm-release
           FILE_TO_UPDATE: misc/source-releases/bosh.yml
       - put: compiled-releases
         params:

--- a/ci/tasks/update-source-release.sh
+++ b/ci/tasks/update-source-release.sh
@@ -29,8 +29,10 @@ bosh int bosh-deployment/${FILE_TO_UPDATE} -o update-release-ops.yml > $TMP
 mv $TMP bosh-deployment-output/${FILE_TO_UPDATE}
 
 pushd $PWD/bosh-deployment-output
-  git add -A
-  git config --global user.email "ci@localhost"
-  git config --global user.name "CI Bot"
-  git commit -m "Bumping $RELEASE_NAME to version $VERSION"
+  if ! git diff --quiet --exit-code; then
+    git add -A
+    git config --global user.email "ci@localhost"
+    git config --global user.name "CI Bot"
+    git commit -m "Bumping $RELEASE_NAME to version $VERSION"
+  fi
 popd

--- a/misc/source-releases/bosh.yml
+++ b/misc/source-releases/bosh.yml
@@ -11,6 +11,6 @@
   type: replace
   value:
     name: bpm
-    sha1: 41df19697d6a69d2552bc2c132928157fa91abe0
-    url: https://bosh.io/d/github.com/cloudfoundry-incubator/bpm-release?v=1.0.4
-    version: 1.0.4
+    sha1: 82e83a5e8ebd6e07f6ca0765e94eb69e03324a19
+    url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.0
+    version: 1.1.0

--- a/vsphere/cpi-secondary.yml
+++ b/vsphere/cpi-secondary.yml
@@ -3,9 +3,9 @@
   path: /releases/-
   value:
     name: bosh-vsphere-cpi
-    version: "50"
-    url: https://bosh.io/d/github.com/cloudfoundry/bosh-vsphere-cpi-release?v=50
-    sha1: 725215b56aece1709d347adc709849a8960396ef
+    sha1: b3587311b7f7403818e25989d9ed5eed99d65193
+    url: https://bosh.io/d/github.com/cloudfoundry/bosh-vsphere-cpi-release?v=52.1.1
+    version: 52.1.1
 
 - type: replace
   path: /instance_groups/name=bosh/properties/vcenter?

--- a/vsphere/cpi.yml
+++ b/vsphere/cpi.yml
@@ -2,9 +2,9 @@
   type: replace
   value:
     name: bosh-vsphere-cpi
-    sha1: 73f4cd14eef75e037d6ca553ee63d8b55062f0ab
-    url: https://bosh.io/d/github.com/cloudfoundry/bosh-vsphere-cpi-release?v=52
-    version: "52"
+    sha1: b3587311b7f7403818e25989d9ed5eed99d65193
+    url: https://bosh.io/d/github.com/cloudfoundry/bosh-vsphere-cpi-release?v=52.1.1
+    version: 52.1.1
 - name: stemcell
   path: /resource_pools/name=vms/stemcell?
   type: replace


### PR DESCRIPTION
From <https://github.com/cloudfoundry/bosh-vsphere-cpi-release/releases>
- Fixes DRS Lock timeout issue
- Adds support for NSX-V Manager 6.4.2

The keys `version`, `url`, and `sha1` are now sorted alphabetically.