### PR TITLE
Remove unneccesary uaa.login.client_secret property

### DIFF
--- a/uaa.yml
+++ b/uaa.yml
@@ -69,8 +69,6 @@
             keys:
               uaa-jwt-key-1:
                 signingKey: ((uaa_jwt_signing_key.private_key))
-        login:
-          client_secret: ((uaa_login_client_secret))
         scim:
           groups:
             bosh.admin: User has admin access on any Director
@@ -120,11 +118,6 @@
   type: replace
   value:
     name: uaa_admin_client_secret
-    type: password
-- path: /variables/-
-  type: replace
-  value:
-    name: uaa_login_client_secret
     type: password
 - path: /variables/-
   type: replace


### PR DESCRIPTION
A similar issue in cf-deployment can be found here: cloudfoundry/cf-deployment#85

There is no uaa.login.client_secret property specified in the uaa-release's job spec.