### PR TITLE
Add current-version.yml to offline installation opsfiles

### DIFF
--- a/misc/no-internet-access/current-versions.yml
+++ b/misc/no-internet-access/current-versions.yml
@@ -1,0 +1,20 @@
+
+- type: replace
+  path: /releases/name=bpm/version
+  value: 1.1.3
+
+- type: replace
+  path: /releases/name=credhub/version
+  value: 2,5.6
+
+- type: replace
+  path: /releases/name=os-conf/version
+  value: 21.0.0
+
+- type: replace
+  path: /releases/name=uaa/version
+  value: 74.1.0
+
+- type: replace
+  path: /releases/name=bosh-vsphere-cpi/version
+  value: 53.0.1


### PR DESCRIPTION
This PR provides a file for a compatibility matrix of versions during offline installation of Bosh.
(issue #336 )