### PR TITLE
default credhub.certificates.concatenate_cas to true

### DIFF
--- a/credhub.yml
+++ b/credhub.yml
@@ -21,6 +21,8 @@
         authorization:
           acls:
             enabled: false
+        certificates:
+          concatenate_cas: true
         data_storage:
           database: credhub
           host: 127.0.0.1


### PR DESCRIPTION
This setting allows ops-file free rotation of certificates which are generally much less painful than using ops files. I talked to @jfmyers9 and he too agrees that defaulting to true is better than adding a second ops file for this. The credhub instructions can be found here: https://github.com/pivotal-cf/credhub-release/blob/master/docs/ca-rotation.md

I ran the test suite and it succeeded.