### PR TITLE
Remove obsolete blobstore certificates when using external blobstore

### DIFF
--- a/alicloud/oss-blobstore.yml
+++ b/alicloud/oss-blobstore.yml
@@ -18,3 +18,9 @@
     host: ((oss-host))
     access_key_id: ((oss-access-key-id))
     secret_access_key: ((oss-access-key-secret))
+
+- type: remove
+  path: /variables/name=blobstore_ca?
+
+- type: remove
+  path: /variables/name=blobstore_server_tls?

--- a/aws/s3-blobstore.yml
+++ b/aws/s3-blobstore.yml
@@ -23,3 +23,9 @@
       access_key_id: ((s3-access-key-id))
       secret_access_key: ((s3-secret-access-key))
       region: ((s3-region))
+
+- type: remove
+  path: /variables/name=blobstore_ca?
+
+- type: remove
+  path: /variables/name=blobstore_server_tls?

--- a/gcp/gcs-blobstore.yml
+++ b/gcp/gcs-blobstore.yml
@@ -21,3 +21,9 @@
       credentials_source: static
       bucket_name: ((bucket_name))
       json_key: ((agent_gcs_credentials_json))
+
+- type: remove
+  path: /variables/name=blobstore_ca?
+
+- type: remove
+  path: /variables/name=blobstore_server_tls?


### PR DESCRIPTION
This PR removes blobstore certificates from variables which when using an external blobstore. We have alerting in place for every certificate in credhub, so we would either renew it or exclude it. But that does not make sense as the certificate has no meaning when using an external blobstore in the first place.