### PR TITLE
Add ops file for metrics server

### DIFF
--- a/experimental/enable-metrics.yml
+++ b/experimental/enable-metrics.yml
@@ -1,0 +1,46 @@
+- path: /instance_groups/name=bosh/properties/director/metrics_server?/enabled?
+  type: replace
+  value: true
+- path: /instance_groups/name=bosh/properties/director/metrics_server?/tls?/ca?
+  type: replace
+  value: ((metrics_server_tls.ca))
+- path: /instance_groups/name=bosh/properties/director/metrics_server?/tls?/certificate?
+  type: replace
+  value: ((metrics_server_tls.certificate))
+- path: /instance_groups/name=bosh/properties/director/metrics_server?/tls?/private_key?
+  type: replace
+  value: ((metrics_server_tls.private_key))
+
+# metrics_server ca
+- path: /variables/-
+  type: replace
+  value:
+    name: metrics_server_ca
+    type: certificate
+    options:
+      common_name: bosh-metrics-server
+      is_ca: true
+
+# metrics_server server certs
+- path: /variables/-
+  type: replace
+  value:
+    name: metrics_server_tls
+    type: certificate
+    options:
+      alternative_names:
+        - ((internal_ip)) # external ip?
+      ca: metrics_server_ca
+      extended_key_usage:
+        - server_auth
+
+# metrics_server client certs
+- path: /variables/-
+  type: replace
+  value:
+    name: metrics_server_client_tls
+    type: certificate
+    options:
+      ca: metrics_server_ca
+      extended_key_usage:
+        - client_auth

--- a/experimental/enable-metrics.yml
+++ b/experimental/enable-metrics.yml
@@ -1,18 +1,18 @@
-- path: /instance_groups/name=bosh/properties/director/metrics_server?/enabled?
+- path: /instance_groups/name=bosh/properties/director/metrics_server?/enabled
   type: replace
   value: true
-- path: /instance_groups/name=bosh/properties/director/metrics_server?/tls?/ca?
+- path: /instance_groups/name=bosh/properties/director/metrics_server?/tls/ca
   type: replace
   value: ((metrics_server_tls.ca))
-- path: /instance_groups/name=bosh/properties/director/metrics_server?/tls?/certificate?
+- path: /instance_groups/name=bosh/properties/director/metrics_server?/tls/certificate
   type: replace
   value: ((metrics_server_tls.certificate))
-- path: /instance_groups/name=bosh/properties/director/metrics_server?/tls?/private_key?
+- path: /instance_groups/name=bosh/properties/director/metrics_server?/tls/private_key
   type: replace
   value: ((metrics_server_tls.private_key))
 
 # metrics_server ca
-- path: /variables/-
+- path: /variables/name=metrics_server_ca?
   type: replace
   value:
     name: metrics_server_ca
@@ -22,20 +22,20 @@
       is_ca: true
 
 # metrics_server server certs
-- path: /variables/-
+- path: /variables/name=metrics_server_tls?
   type: replace
   value:
     name: metrics_server_tls
     type: certificate
     options:
       alternative_names:
-        - ((internal_ip)) # external ip?
+        - ((internal_ip))
       ca: metrics_server_ca
       extended_key_usage:
         - server_auth
 
 # metrics_server client certs
-- path: /variables/-
+- path: /variables/name=metrics_server_client_tls?
   type: replace
   value:
     name: metrics_server_client_tls


### PR DESCRIPTION
This ops file doesn't actually make sense until a release is cut with the metrics server, so this is a PR instead of a direct push to develop. It should be merged when the next release after 270.8.0 is cut.

[#169550810](https://www.pivotaltracker.com/story/show/169550810)