### PR TITLE
[misc][source-releases] Adds ops file to use source files for bbr

### DIFF
--- a/misc/source-releases/bbr.yml
+++ b/misc/source-releases/bbr.yml
@@ -1,0 +1,7 @@
+- type: replace
+  path: /release/name=backup-and-restore-sdk
+  value:
+    name: backup-and-restore-sdk
+    sha1: fca251cf474c67c38fafe531a314b3cfd2e91c0d
+    url: https://bosh.io/d/github.com/cloudfoundry-incubator/backup-and-restore-sdk-release?v=1.17.2
+    version: 1.17.2


### PR DESCRIPTION
Currently there are ops file for uaa, credhub + bosh to not use precompiled ops files but source releases instead. As there was no ops file for bbr so far I prepared one.