### PR TITLE
Fix NTP setting for bosh director

### DIFF
--- a/bosh.yml
+++ b/bosh.yml
@@ -158,11 +158,11 @@ resource_pools:
       mbus:
         cert: ((mbus_bootstrap_ssl))
       password: '*'
-    ntp:
-    - time1.google.com
-    - time2.google.com
-    - time3.google.com
-    - time4.google.com
+      ntp:
+      - time1.google.com
+      - time2.google.com
+      - time3.google.com
+      - time4.google.com
   name: vms
   network: default
 variables:


### PR DESCRIPTION
Indent for the `env.bosh.ntp` YAML node that apply to the BOSH director is currently wrong.

This fixes #388