### PR TITLE
[ci] Add auto-bump for alicloud stemcell + cpi

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -847,7 +847,7 @@ resources:
 - name: alicloud-ubuntu-xenial-stemcell
   type: bosh-io-stemcell
   source:
-    name: bosh-alicloud-xen-hvm-ubuntu-xenial-go_agent
+    name: bosh-alicloud-kvm-ubuntu-xenial-go_agent
 
 - name: azure-ubuntu-xenial-stemcell
   type: bosh-io-stemcell

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -11,6 +11,7 @@ groups:
   - update-aws-cpi
   - update-google-cpi
   - update-azure-cpi
+  - update-alicloud-cpi
   - update-vsphere-cpi-release
   - update-virtualbox-cpi-release
   - update-openstack-cpi-release
@@ -18,6 +19,7 @@ groups:
   jobs:
   - update-aws-stemcell
   - update-azure-stemcell
+  - update-alicloud-stemcell
   - update-docker-stemcell
   - update-gcp-stemcell
   - update-openstack-stemcell
@@ -136,6 +138,26 @@ jobs:
     params:
       CPI_NAME: bosh-azure-cpi
       CPI_OPS_FILE: azure/cpi.yml
+  - put: bosh-deployment
+    params:
+      repository: bosh-deployment
+      rebase: true
+
+- name: update-alicloud-cpi
+  plan:
+  - in_parallel:
+    - get: bosh-deployment
+      params:
+        clean_tags: true
+    - get: alicloud-cpi-release
+      trigger: true
+  - task: update-release
+    file: bosh-deployment/ci/tasks/update-cpi.yml
+    input_mapping:
+      cpi: alicloud-cpi-release
+    params:
+      CPI_OPS_FILE: alicloud/cpi.yml
+      CPI_NAME: bosh-alicloud-cpi
   - put: bosh-deployment
     params:
       repository: bosh-deployment
@@ -552,6 +574,26 @@ jobs:
       repository: bosh-deployment
       rebase: true
 
+- name: update-alicloud-stemcell
+  plan:
+  - in_parallel:
+    - get: bosh-deployment
+      params:
+        clean_tags: true
+    - get: alicloud-ubuntu-xenial-stemcell
+      trigger: true
+  - task: update-stemcell
+    file: bosh-deployment/ci/tasks/update-stemcell.yml
+    input_mapping:
+      stemcell: alicloud-ubuntu-xenial-stemcell
+    params:
+      CPI_OPS_FILE: alicloud/cpi.yml
+      STEMCELL_NAME: alicloud-ubuntu-xenial-stemcell
+  - put: bosh-deployment
+    params:
+      repository: bosh-deployment
+      rebase: true
+
 - name: update-azure-stemcell
   plan:
   - in_parallel:
@@ -802,6 +844,11 @@ resources:
   source:
     name: bosh-aws-xen-hvm-ubuntu-xenial-go_agent
 
+- name: alicloud-ubuntu-xenial-stemcell
+  type: bosh-io-stemcell
+  source:
+    name: bosh-alicloud-xen-hvm-ubuntu-xenial-go_agent
+
 - name: azure-ubuntu-xenial-stemcell
   type: bosh-io-stemcell
   source:
@@ -895,6 +942,11 @@ resources:
   type: bosh-io-release
   source:
     repository: cloudfoundry/bosh-aws-cpi-release
+
+- name: alicloud-cpi-release
+  type: bosh-io-release
+  source:
+    repository: cloudfoundry-incubator/bosh-alicloud-cpi-release
 
 - name: azure-cpi-release
   type: bosh-io-release


### PR DESCRIPTION
I just recognized that the alicloud cpi + stemcells were not updated since 5 months now, however there had been some new releases. So I prepared adding the alicloud cpi + stemcell to CI so it is getting auto bumped in the future. 