### PR TITLE
Correct path to backup-and-restore-sdk source release

### DIFF
--- a/misc/source-releases/bbr.yml
+++ b/misc/source-releases/bbr.yml
@@ -1,4 +1,4 @@
-- path: /release/name=backup-and-restore-sdk
+- path: /releases/name=backup-and-restore-sdk
   release: backup-and-restore-sdk
   type: replace
   value:


### PR DESCRIPTION
The location for the release is under `releases`, but this op file incorrectly specified `release` as the path.