### PR TITLE
Revert "Correct path to backup-and-restore-sdk source release"

### DIFF
--- a/misc/source-releases/bbr.yml
+++ b/misc/source-releases/bbr.yml
@@ -1,4 +1,4 @@
-- path: /releases/name=backup-and-restore-sdk
+- path: /release/name=backup-and-restore-sdk
   release: backup-and-restore-sdk
   type: replace
   value:


### PR DESCRIPTION
Reverts cloudfoundry/bosh-deployment#398

- this needs to go in the develop branch. Not master