### PR TITLE
Add ops files to enable local or external dns monitoring

### DIFF
--- a/misc/dns-addon-enable-external-monitoring.yml
+++ b/misc/dns-addon-enable-external-monitoring.yml
@@ -1,0 +1,7 @@
+- type: replace
+  path: /addons/name=bosh-dns/jobs/name=bosh-dns/properties?/metrics?/enabled
+  value: true
+
+- type: replace
+  path: /addons/name=bosh-dns/jobs/name=bosh-dns/properties?/metrics?/address
+  value: ((address-to-bind-dns-metrics))

--- a/misc/dns-addon-enable-external-monitoring.yml
+++ b/misc/dns-addon-enable-external-monitoring.yml
@@ -5,3 +5,7 @@
 - type: replace
   path: /addons/name=bosh-dns/jobs/name=bosh-dns/properties?/metrics?/address
   value: ((address-to-bind-dns-metrics))
+
+- type: replace
+  path: /addons/name=bosh-dns/jobs/name=bosh-dns/properties?/metrics?/port
+  value: ((port-to-bind-dns-metrics))

--- a/misc/dns-addon-enable-local-monitoring.yml
+++ b/misc/dns-addon-enable-local-monitoring.yml
@@ -1,0 +1,3 @@
+- type: replace
+  path: /addons/name=bosh-dns/jobs/name=bosh-dns/properties?/metrics?/enabled
+  value: true


### PR DESCRIPTION
This ops file could be used to enable bosh-dns monitoring for the add-on if need. The ops files are referenced in this docs-bosh pr https://github.com/cloudfoundry/docs-bosh/pull/732