### PR TITLE
Add openstack raw stemcell

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -21,6 +21,7 @@ groups:
   - update-docker-stemcell
   - update-gcp-stemcell
   - update-openstack-stemcell
+  - update-openstack-raw-stemcell
   - update-vcloud-stemcell
   - update-virtualbox-stemcell
   - update-vsphere-stemcell
@@ -632,6 +633,26 @@ jobs:
       repository: bosh-deployment
       rebase: true
 
+- name: update-openstack-raw-stemcell
+  plan:
+  - in_parallel:
+    - get: bosh-deployment
+      params:
+        clean_tags: true
+    - get: openstack-ubuntu-xenial-stemcell-raw
+      trigger: true
+  - task: update-stemcell
+    file: bosh-deployment/ci/tasks/update-stemcell.yml
+    input_mapping:
+      stemcell: openstack-ubuntu-xenial-stemcell-raw
+    params:
+      CPI_OPS_FILE: openstack/use-openstack-raw-stemcell.yml
+      STEMCELL_NAME: openstack-ubuntu-xenial-stemcell-raw
+  - put: bosh-deployment
+    params:
+      repository: bosh-deployment
+      rebase: true
+
 - name: update-vcloud-stemcell
   plan:
   - in_parallel:
@@ -817,6 +838,12 @@ resources:
   type: bosh-io-stemcell
   source:
     name: bosh-openstack-kvm-ubuntu-xenial-go_agent
+    force_regular: true
+
+- name: openstack-ubuntu-xenial-stemcell-raw
+  type: bosh-io-stemcell
+  source:
+    name: bosh-openstack-kvm-ubuntu-xenial-go_agent-raw
     force_regular: true
 
 - name: vcloud-ubuntu-xenial-stemcell

--- a/openstack/use-openstack-raw-stemcell.yml
+++ b/openstack/use-openstack-raw-stemcell.yml
@@ -1,0 +1,6 @@
+- name: stemcell
+  path: /resource_pools/name=vms/stemcell?
+  type: replace
+  value:
+    sha1: 0e4b7321efee854b275901b046a240ca8c1de371
+    url: https://bosh-core-stemcells.s3-accelerate.amazonaws.com/621.85/bosh-stemcell-621.85-openstack-kvm-ubuntu-xenial-go_agent-raw.tgz


### PR DESCRIPTION
Note: Please create PR's against the develop branch

As there are some people that need to use the raw version of the openstack stemcell it would be nice to have an ops file to easily switch over to that. In addition, the raw stemcell should be always up-to-date therefore I added it to CI.