### PR TITLE
Added runtime-config/os-conf.yml against icmp-timestamp-response-cve-1999-0524

### DIFF
--- a/runtime-configs/os-conf.yml
+++ b/runtime-configs/os-conf.yml
@@ -1,0 +1,19 @@
+releases:
+- name: "os-conf"
+  url:  "https://bosh.io/d/github.com/cloudfoundry/os-conf-release?v=22.1.0"
+  sha1: "7ef05f6f3ebc03f59ad8131851dbd1abd1ab3663"
+  version: "22.1.0"
+
+addons:
+- include:
+    stemcell:
+    - os: ubuntu-trusty
+    - os: ubuntu-xenial
+  name: os-configuration
+  jobs:
+  - name: sysctl
+    release: os-conf
+    properties:
+      sysctl:
+      - net.ipv4.tcp_timestamps=0
+


### PR DESCRIPTION
The VMs created by BOSH responded with a TCP timestamp.
The information in these responses could be leveraged in other exploits of the ACOS system despite low-level security.
This PR prevents the presence of responses to ICMP timestamp requests.

ref.
https://support.a10networks.com/support/security_advisory/icmp-timestamp-response-cve-1999-0524

Note: Please create PR's against the develop branch