### PR TITLE
Add SANs to bosh dns certificates

### DIFF
--- a/runtime-configs/dns.yml
+++ b/runtime-configs/dns.yml
@@ -61,6 +61,8 @@ variables:
   options:
     ca: /dns_healthcheck_tls_ca
     common_name: health.bosh-dns
+    alternative_names:
+    - health.bosh-dns
     extended_key_usage:
     - server_auth
   type: certificate
@@ -68,6 +70,8 @@ variables:
   options:
     ca: /dns_healthcheck_tls_ca
     common_name: health.bosh-dns
+    alternative_names:
+    - health.bosh-dns
     extended_key_usage:
     - client_auth
   type: certificate
@@ -80,6 +84,8 @@ variables:
   options:
     ca: /dns_api_tls_ca
     common_name: api.bosh-dns
+    alternative_names:
+    - api.bosh-dns
     extended_key_usage:
     - server_auth
   type: certificate
@@ -87,6 +93,8 @@ variables:
   options:
     ca: /dns_api_tls_ca
     common_name: api.bosh-dns
+    alternative_names:
+    - api.bosh-dns
     extended_key_usage:
     - client_auth
   type: certificate


### PR DESCRIPTION
This is necessary to fix the regression introduced in bosh-dns 1.28.0.

See https://github.com/cloudfoundry/bosh-dns-release/issues/76

It might also be desirable to set `update_mode: converge` on these certificates?