### PR TITLE
Added ops files to use Bionic stemcells

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This repository is intended to serve as a reference and starting point for developer-friendly configuration of the Bosh Director. Consume the `master` branch. Any changes should be made against the `develop` branch (it will be automatically promoted once it passes tests).
 
+## Use Bionic stemcells
+
+Beta versions of Bionic stemcells are available on [Bosh.io](https://bosh.io/stemcells/). To enable the Bionic stemcell append the ops file `[IAAS]/use-bionic.yml` after the ops file `[IAAS]/cpi.yml`.
+
 ## Important notice for users of bosh-deployment and Bosh DNS versions older than 1.28
 
 As of Bosh DNS version 1.28, Bosh DNS is now built with Go 1.15. This version of Go demands that TLS certificates be created with a SAN field, in addition to the usual CN field.
@@ -59,6 +63,7 @@ Other releases such as [UAA](https://github.com/cloudfoundry/uaa-release), [Cred
 
 - `bosh.yml`: Base manifest that is meant to be used with different CPI configurations
 - `[alicloud|aws|azure|docker|gcp|openstack|softlayer|vcloud|vsphere|virtualbox]/cpi.yml`: CPI configuration
+- `[alicloud|aws|azure|docker|gcp|openstack|softlayer|vcloud|virtualbox|vsphere|warden]/use-bionic.yml`: use Bionic stemcell (beta version) instead of Xenial stemcell.
 - `[alicloud|aws|azure|docker|gcp|openstack|softlayer|vcloud|vsphere|virtualbox]/cloud-config.yml`: Simple cloud configs
 - `jumpbox-user.yml`: Adds user `jumpbox` for SSH-ing into the Director (see [Jumpbox User](docs/jumpbox-user.md))
 - `uaa.yml`: Deploys UAA and enables UAA user management in the Director

--- a/alicloud/use-bionic.yml
+++ b/alicloud/use-bionic.yml
@@ -1,0 +1,5 @@
+- type: replace
+  path: /resource_pools/name=vms/stemcell?
+  value:
+    sha1: 9174a7ced02f71227a3988375df205ea92c5d9af
+    url: https://bosh-alicloud-light-stemcells-cn.oss-cn-hangzhou.aliyuncs.com/light-bosh-stemcell-0.13-alicloud-kvm-ubuntu-bionic-go_agent.tgz

--- a/aws/use-bionic.yml
+++ b/aws/use-bionic.yml
@@ -1,0 +1,5 @@
+- type: replace
+  path: /resource_pools/name=vms/stemcell?
+  value:
+    sha1: aed1b76c06629bc92be7c449f0564a136ba867a1
+    url: https://bosh-aws-light-stemcells.s3-accelerate.amazonaws.com/0.13/light-bosh-stemcell-0.13-aws-xen-hvm-ubuntu-bionic-go_agent.tgz

--- a/azure/use-bionic.yml
+++ b/azure/use-bionic.yml
@@ -1,0 +1,5 @@
+- type: replace
+  path: /resource_pools/name=vms/stemcell?
+  value:
+    sha1: 75743bbf1ed7465054f75e68fed1579d28476694
+    url: https://bosh-core-stemcells.s3-accelerate.amazonaws.com/0.13/bosh-stemcell-0.13-azure-hyperv-ubuntu-bionic-go_agent.tgz

--- a/docker/use-bionic.yml
+++ b/docker/use-bionic.yml
@@ -1,0 +1,5 @@
+- type: replace
+  path: /resource_pools/name=vms/stemcell?
+  value:
+    sha1: 32f135ae6cda083a8c4291ad7bc18a6be68a5d52
+    url: https://bosh-core-stemcells.s3-accelerate.amazonaws.com/0.13/bosh-stemcell-0.13-warden-boshlite-ubuntu-bionic-go_agent.tgz

--- a/gcp/use-bionic.yml
+++ b/gcp/use-bionic.yml
@@ -1,0 +1,5 @@
+- type: replace
+  path: /resource_pools/name=vms/stemcell?
+  value:
+    sha1: ad078f46f4fc5c8b214cb1f28ac3ef03c0506f13
+    url: https://bosh-gce-light-stemcells.s3-accelerate.amazonaws.com/0.13/light-bosh-stemcell-0.13-google-kvm-ubuntu-bionic-go_agent.tgz

--- a/openstack/use-bionic.yml
+++ b/openstack/use-bionic.yml
@@ -1,0 +1,5 @@
+- type: replace
+  path: /resource_pools/name=vms/stemcell?
+  value:
+    sha1: cdfb88e0f09f920cc08e5edcad33b9cd2eacc6d4
+    url: https://bosh-core-stemcells.s3-accelerate.amazonaws.com/0.13/bosh-stemcell-0.13-openstack-kvm-ubuntu-bionic-go_agent.tgz

--- a/softlayer/use-bionic.yml
+++ b/softlayer/use-bionic.yml
@@ -1,0 +1,5 @@
+- type: replace
+  path: /resource_pools/name=vms/stemcell?
+  value:
+    sha1: 360ef5c0b526b9c7af5c5b94609ffaaf605367ed
+    url: https://s3.amazonaws.com/bosh-softlayer-cpi-stemcells/light-bosh-stemcell-0.6-softlayer-xen-ubuntu-bionic-go_agent.tgz

--- a/vcloud/use-bionic.yml
+++ b/vcloud/use-bionic.yml
@@ -1,0 +1,5 @@
+- type: replace
+  path: /resource_pools/name=vms/stemcell?
+  value:
+    sha1: c7adbb8b8749a1f98909324f9612cdb759282dc6
+    url: https://bosh-core-stemcells.s3-accelerate.amazonaws.com/0.13/bosh-stemcell-0.13-vcloud-esxi-ubuntu-bionic-go_agent.tgz

--- a/virtualbox/use-bionic.yml
+++ b/virtualbox/use-bionic.yml
@@ -1,0 +1,5 @@
+- type: replace
+  path: /resource_pools/name=vms/stemcell?
+  value:
+    sha1: 900b6bde99a0f454e2860c4eac740af6da376f38
+    url: https://bosh-core-stemcells.s3-accelerate.amazonaws.com/0.13/bosh-stemcell-0.13-vsphere-esxi-ubuntu-bionic-go_agent.tgz

--- a/vsphere/use-bionic.yml
+++ b/vsphere/use-bionic.yml
@@ -1,0 +1,5 @@
+- type: replace
+  path: /resource_pools/name=vms/stemcell?
+  value:
+    sha1: 900b6bde99a0f454e2860c4eac740af6da376f38
+    url: https://bosh-core-stemcells.s3-accelerate.amazonaws.com/0.13/bosh-stemcell-0.13-vsphere-esxi-ubuntu-bionic-go_agent.tgz

--- a/warden/use-bionic.yml
+++ b/warden/use-bionic.yml
@@ -1,0 +1,5 @@
+- type: replace
+  path: /resource_pools/name=vms/stemcell?
+  value:
+    sha1: 32f135ae6cda083a8c4291ad7bc18a6be68a5d52
+    url: https://bosh-core-stemcells.s3-accelerate.amazonaws.com/0.13/bosh-stemcell-0.13-warden-boshlite-ubuntu-bionic-go_agent.tgz


### PR DESCRIPTION
This PR is a replacement for PR https://github.com/cloudfoundry/bosh-deployment/pull/404.
Story: https://www.pivotaltracker.com/n/projects/956238/stories/175232093

**Changes:**
- Added ops files for all available IAAS
- Moved ops files `use-bionic.yml` to the IAAS folder as discussed in the previous PR
- Updated to the latest available bionic stemcell version
- Updated Readme file