### PR TITLE
Revert "[ci] Add auto-bump for alicloud stemcell + cpi"

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -11,7 +11,6 @@ groups:
   - update-aws-cpi
   - update-google-cpi
   - update-azure-cpi
-  - update-alicloud-cpi
   - update-vsphere-cpi-release
   - update-virtualbox-cpi-release
   - update-openstack-cpi-release
@@ -19,7 +18,6 @@ groups:
   jobs:
   - update-aws-stemcell
   - update-azure-stemcell
-  - update-alicloud-stemcell
   - update-docker-stemcell
   - update-gcp-stemcell
   - update-openstack-stemcell
@@ -139,26 +137,6 @@ jobs:
     params:
       CPI_NAME: bosh-azure-cpi
       CPI_OPS_FILE: azure/cpi.yml
-  - put: bosh-deployment
-    params:
-      repository: bosh-deployment
-      rebase: true
-
-- name: update-alicloud-cpi
-  plan:
-  - in_parallel:
-    - get: bosh-deployment
-      params:
-        clean_tags: true
-    - get: alicloud-cpi-release
-      trigger: true
-  - task: update-release
-    file: bosh-deployment/ci/tasks/update-cpi.yml
-    input_mapping:
-      cpi: alicloud-cpi-release
-    params:
-      CPI_OPS_FILE: alicloud/cpi.yml
-      CPI_NAME: bosh-alicloud-cpi
   - put: bosh-deployment
     params:
       repository: bosh-deployment
@@ -575,26 +553,6 @@ jobs:
       repository: bosh-deployment
       rebase: true
 
-- name: update-alicloud-stemcell
-  plan:
-  - in_parallel:
-    - get: bosh-deployment
-      params:
-        clean_tags: true
-    - get: alicloud-ubuntu-xenial-stemcell
-      trigger: true
-  - task: update-stemcell
-    file: bosh-deployment/ci/tasks/update-stemcell.yml
-    input_mapping:
-      stemcell: alicloud-ubuntu-xenial-stemcell
-    params:
-      CPI_OPS_FILE: alicloud/cpi.yml
-      STEMCELL_NAME: alicloud-ubuntu-xenial-stemcell
-  - put: bosh-deployment
-    params:
-      repository: bosh-deployment
-      rebase: true
-
 - name: update-azure-stemcell
   plan:
   - in_parallel:
@@ -865,11 +823,6 @@ resources:
   source:
     name: bosh-aws-xen-hvm-ubuntu-xenial-go_agent
 
-- name: alicloud-ubuntu-xenial-stemcell
-  type: bosh-io-stemcell
-  source:
-    name: bosh-alicloud-kvm-ubuntu-xenial-go_agent
-
 - name: azure-ubuntu-xenial-stemcell
   type: bosh-io-stemcell
   source:
@@ -969,11 +922,6 @@ resources:
   type: bosh-io-release
   source:
     repository: cloudfoundry/bosh-aws-cpi-release
-
-- name: alicloud-cpi-release
-  type: bosh-io-release
-  source:
-    repository: cloudfoundry-incubator/bosh-alicloud-cpi-release
 
 - name: azure-cpi-release
   type: bosh-io-release


### PR DESCRIPTION
Reverts cloudfoundry/bosh-deployment#394

Unfortunately this change won't work right now, as the `bosh-alicloud-cpi-release` is not published on [bosh.io](https://bosh.io/releases/).

This is because releases cannot be build from the [bosh-alicloud-cpi-release](https://github.com/cloudfoundry-incubator/bosh-alicloud-cpi-release) repository, due to it using a local blobstore.

There's been an open issue on this repo for some time here: https://github.com/cloudfoundry-incubator/bosh-alicloud-cpi-release/issues/77