### PR TITLE
Bump alicloud CPI v34.0.0

### DIFF
--- a/alicloud/cpi.yml
+++ b/alicloud/cpi.yml
@@ -2,9 +2,9 @@
   type: replace
   value:
     name: bosh-alicloud-cpi
-    sha1: 9ea843cc34ccf61d0c6809c9f6cdfd7da29bc7f1
-    url: https://github.com/cloudfoundry-incubator/bosh-alicloud-cpi-release/releases/download/v24.0.0/bosh-alicloud-cpi-release-24.0.0.tgz
-    version: 24.0.0
+    sha1: 93768978946838bcc52a724b2157e14109d1f705
+    url: https://github.com/cloudfoundry-incubator/bosh-alicloud-cpi-release/releases/download/v34.0.0/bosh-alicloud-cpi-release-34.0.0.tgz
+    version: 34.0.0
 - name: stemcell
   path: /resource_pools/name=vms/stemcell?
   type: replace


### PR DESCRIPTION
Note: Please create PR's against the develop branch

As auto-bump for alicloud CPI is not working we should bump CPI to latest release:

https://github.com/cloudfoundry-incubator/bosh-alicloud-cpi-release/releases/tag/v34.0.0