### PR TITLE
Remove unnecessary properties for Agent creds

### DIFF
--- a/bosh.yml
+++ b/bosh.yml
@@ -52,9 +52,6 @@ instance_groups:
       mbus: nats://nats:((nats_password))@((internal_ip)):4222
     blobstore:
       address: ((internal_ip))
-      agent:
-        password: ((blobstore_agent_password))
-        user: agent
       director:
         password: ((blobstore_director_password))
         user: director


### PR DESCRIPTION
This PR relates directly to cloudfoundry/bosh#2325.

The properties `blobstore.agent.user` and `blobstore.agent.password` are not used within the BOSH Director's code base.

Any Blobstore credentials overrides are supposed to be provided by the `agent.env.bosh.blobstores` array in the director's job properties.

Co-Authored-By: @olivermautschke
