### PR TITLE
Add CloudStack support

### DIFF
--- a/cloudstack/auto-anti-affinity.yml
+++ b/cloudstack/auto-anti-affinity.yml
@@ -1,0 +1,4 @@
+---
+- type: replace
+  path: /instance_groups/name=bosh/properties/cloudstack/enable_auto_anti_affinity?
+  value: true

--- a/cloudstack/cpi.yml
+++ b/cloudstack/cpi.yml
@@ -1,0 +1,130 @@
+---
+
+- name: cpi
+  path: /releases/-
+  type: replace
+  value:
+    name: bosh-go-cpi-cloudstack
+    sha1: cdfb6b605b05024895358ec5a9f36b45f0e2a70f
+    url: https://github.com/orange-cloudfoundry/bosh-go-cpi-cloudstack/releases/download/v2.3.0/bosh-go-cpi-cloudstack-2.3.0.tgz
+    version: 2.3.0
+
+- name: stemcell
+  path: /resource_pools/name=vms/stemcell?
+  type: replace
+  value:
+    # currently the stemcells are not released to bosh.io and you need to build them yourself
+    # you are welcome to submit a request (or make yourself known in https://github.com/cloudfoundry/bosh-linux-stemcell-builder/pull/175)
+    url: ((stemcell_url))
+    sha1: ((stemcell_sha1))
+
+# Configure sizes
+- type: replace
+  path: /resource_pools/name=vms/cloud_properties?
+  value:
+    disk: 20_000
+
+- type: replace
+  path: /networks/name=default/subnets/0/cloud_properties?
+  value:
+    name: ((network_name))
+
+# Add CPI job
+- path: /instance_groups/name=bosh/jobs/-
+  type: replace
+  value: &cpi_job
+    name: cloudstack_cpi
+    release: bosh-go-cpi-cloudstack
+
+# Configure sizes
+- type: replace
+  path: /resource_pools/name=vms/cloud_properties?
+  value:
+    compute_offering: ((cloudstack_compute_offering))
+    disk: 25_000
+    ephemeral_disk_offering: shared.custom
+    root_disk_size: 15_000
+
+- type: replace
+  path: /disk_pools/name=disks/cloud_properties?
+  value:
+    disk_offering: shared.custom
+
+- type: replace
+  path: /instance_groups/name=bosh/properties/director/cpi_job?
+  value: cloudstack_cpi
+
+- type: replace
+  path: /cloud_provider/template?
+  value: *cpi_job
+
+- type: replace
+  path: /instance_groups/name=bosh/properties/cloudstack?
+  value: &cloudstack
+    endpoint: ((cloudstack_endpoint))
+    api_key: ((cloudstack_api_key))
+    secret_access_key: ((cloudstack_secret_access_key))
+    default_key_name: ((cloudstack_default_key_name))
+    default_zone: ((cloudstack_zone))
+
+- type: replace
+  path: /instance_groups/name=bosh/jobs/-
+  value:
+    name: registry
+    release: bosh
+
+- path: /instance_groups/name=bosh/properties/registry?
+  type: replace
+  value:
+    address: ((internal_ip))
+    db:
+      adapter: postgres
+      database: bosh
+      host: 127.0.0.1
+      password: ((postgres_password))
+      user: postgres
+    host: ((internal_ip))
+    http:
+      user: registry
+      password: ((registry_password))
+      port: 25777
+    username: registry
+    password: ((registry_password))
+    port: 25777
+
+- type: replace
+  path: /instance_groups/name=bosh/properties/agent/blobstore?
+  value:
+    provider: dav
+    options:
+      endpoint: http://((internal_ip)):25250
+      user: agent
+      password: ((blobstore_agent_password))
+      tls:
+        cert:
+          ca: ((blobstore_ca.certificate))
+
+- type: replace
+  path: /cloud_provider/properties/agent/blobstore?
+  value:
+    provider: local
+    options:
+      blobstore_path: /var/vcap/micro_bosh/data/cache
+
+- path: /cloud_provider/ssh_tunnel?
+  type: replace
+  value:
+    host: ((internal_ip))
+    port: 22
+    private_key: ((private_key))
+    user: vcap
+
+- path: /cloud_provider/properties/cloudstack?
+  type: replace
+  value: *cloudstack
+
+- path: /variables/-
+  type: replace
+  value:
+    name: registry_password
+    type: password


### PR DESCRIPTION
This PR relates to https://github.com/cloudfoundry/bosh-linux-stemcell-builder/pull/175

Notes

1. for the time being, you need to build the `bosh-stemcell` for `cloudstack-xen` yourself from the `cloudfoundry/bosh-linux-stemcell-builder` repository
2. you should overwrite the `bosh-go-cpi-cloudstack` version through an opsfile