### PR TITLE
Allow to configure CA certs for vSphere environments

### DIFF
--- a/vsphere/custom-ca.yml
+++ b/vsphere/custom-ca.yml
@@ -1,0 +1,10 @@
+---
+- type: replace
+  path: /instance_groups/name=bosh/properties/vcenter/connection_options?
+  value:
+    ca_cert: ((vcenter_ca_cert))
+
+- type: replace
+  path: /cloud_provider/properties/vcenter/connection_options?
+  value:
+    ca_cert: ((vcenter_ca_cert))


### PR DESCRIPTION
This PR adds an ops file that allows vSphere users to enable TLS verification which is only enabled when CA certs are provided.

https://github.com/cloudfoundry/bosh-vsphere-cpi-release/blob/v87/src/vsphere_cpi/lib/cloud/vsphere/cpi_http_client.rb#L7-L13
https://github.com/cloudfoundry/bosh-vsphere-cpi-release/blob/v87/src/vsphere_cpi/lib/cloud/vsphere/base_http_client.rb#L19-L23

The directory structure is made identical to openstack's one.