### PR TITLE
CPIs don't support blobstore properties any more

### DIFF
--- a/bosh.yml
+++ b/bosh.yml
@@ -4,9 +4,6 @@ cloud_provider:
   properties:
     agent:
       mbus: https://mbus:((mbus_bootstrap_password))@0.0.0.0:6868
-    blobstore:
-      path: /var/vcap/micro_bosh/data/cache
-      provider: local
 disk_pools:
 - disk_size: 65536
   name: disks


### PR DESCRIPTION
Witht the recent versions of the CPIs the support for blobstore properties has been removed. E.g this
[pr](https://github.com/cloudfoundry/bosh-aws-cpi-release/pull/147) removed it for the AWS CPI. For `create-env` blostore should be configured via the `resource_pools` like
[here](https://github.com/cloudfoundry/bosh-deployment/blob/c62c8bd8265cef7534ba03d6c012601476304d87/bosh.yml#L158-L163)
