### PR TITLE
Disable external IPs for GCP

### DIFF
--- a/gcp/cloud-config.yml
+++ b/gcp/cloud-config.yml
@@ -38,7 +38,7 @@ networks:
     cloud_properties:
       network_name: ((network))
       subnetwork_name: ((subnetwork))
-      ephemeral_external_ip: true
+      ephemeral_external_ip: false
       tags: ((tags))
 - name: vip
   type: vip


### PR DESCRIPTION
* we can use the GCP NAT gateway to enable egress traffic, see PR for bosh-bootloader: https://github.com/cloudfoundry/bosh-bootloader/pull/586
