### PR TITLE
Use blobstore_server_tls.ca for blobstore certificate ca

### DIFF
--- a/bosh.yml
+++ b/bosh.yml
@@ -38,7 +38,7 @@ instance_groups:
               password: ((blobstore_agent_password))
               tls:
                 cert:
-                  ca: ((blobstore_ca.certificate))
+                  ca: ((blobstore_server_tls.ca))
               user: agent
             provider: dav
           ntp:
@@ -59,7 +59,7 @@ instance_groups:
       provider: dav
       tls:
         cert:
-          ca: ((blobstore_ca.certificate))
+          ca: ((blobstore_server_tls.ca))
           certificate: ((blobstore_server_tls.certificate))
           private_key: ((blobstore_server_tls.private_key))
     director:


### PR DESCRIPTION
TLDR;

Use blobstore_server_tls.ca for blobstore certificate ca to be able to use soft rotation via transitional ca in case the deployed director is managed by another director with credhub.

Description: We have a director ("underbosh")) deployed via another director ("overbosh). We use Credhub for underbosh director certificates and therefore can use transitional ca feature in credhub when rotating certificated.

However, the transitional certificate is only shown in the leaf certificate. The `leaf.ca`(in this case `blobstore_server_tls.ca`) then contains the old and new ca certificate but with the current value (`blobstore_ca.certificate`), only the current certificate is used. So when you have created a new CA certificate and updated underbosh, the TLS verification between underbosh and its deployed VMs breaks. Essentially this means that you cannot download logs nor restart the VMs because the VMs only know the old certificate. Only a recreate would fix the issue which does a hard rotation of the blobstore ca certificate.

The proposed change updates the locations where `blobstore_ca.certificate` was used to use the leaf certificate which then provides the transitional certificate in case this credhub certifcate rotation is used.

Note: Please create PR's against the develop branch