### PR TITLE
Update IPv6 ops file to support ipv6 with current bosh manifest

### DIFF
--- a/misc/ipv6/bosh.yml
+++ b/misc/ipv6/bosh.yml
@@ -31,3 +31,11 @@
 - type: replace
   path: /instance_groups/name=bosh/properties/agent/env/bosh/blobstores/0/options/endpoint
   value: "http://[((internal_ip))]:25250"
+
+- type: replace
+  path: /instance_groups/name=bosh/properties/nats/address
+  value: "[((internal_ip))]"
+
+- type: replace
+  path: /resource_pools/name=vms/env/bosh/ipv6?/enable?
+  value: true


### PR DESCRIPTION
The current ops file is not working with the bosh.yml manifest. With this update it's working at least for AWS.