### PR TITLE
do not upload release or make commit if version is the same

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1,4 +1,23 @@
 ---
+commit-when-new-tarball: &commit-when-new-tarball
+  try:
+    do:
+    - task: is-there-new-tarball
+      file: bosh-deployment/ci/tasks/is-there-new-tarball.yml
+      on_success:
+        do:
+          - put: compiled-releases
+            no_get: true
+            params:
+              file: "compiled-release/*.tgz"
+          - put: bosh-deployment
+            params:
+              repository: bosh-deployment
+              rebase: true
+      on_failure:
+        task: echo-skip-message
+        file: bosh-deployment/ci/tasks/echo-skip-upload-message.yml
+
 groups:
 - name: bosh-deployment
   jobs:
@@ -419,14 +438,7 @@ jobs:
     params:
       BOSH_IO_RELEASE: cloudfoundry/bpm-release
       FILE_TO_UPDATE: misc/source-releases/bosh.yml
-  - put: compiled-releases
-    no_get: true
-    params:
-      file: "compiled-release/*.tgz"
-  - put: bosh-deployment
-    params:
-      repository: bosh-deployment
-      rebase: true
+  - <<: *commit-when-new-tarball
 
 - name: compile-credhub-release
   plan:

--- a/ci/tasks/echo-skip-upload-message.yml
+++ b/ci/tasks/echo-skip-upload-message.yml
@@ -1,0 +1,14 @@
+---
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: bosh/docker-cpi
+
+run:
+  path: /bin/bash
+  args:
+    - -exc
+    - |
+      echo "No new tarball was detected. Skipping upload to blobstore and commit so we avoid blobstore checksum mismatches."

--- a/ci/tasks/is-there-new-tarball.yml
+++ b/ci/tasks/is-there-new-tarball.yml
@@ -1,0 +1,22 @@
+---
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: bosh/docker-cpi
+
+inputs:
+- name: bosh-deployment
+
+
+run:
+  path: /bin/bash
+  args:
+    - -exc
+    - |
+      cd ./bosh-deployment
+      git show > /tmp/git-show.patch
+      cat /tmp/git-show.patch
+      grep "^+[[:space:]]*url:" /tmp/git-show.patch
+      exit $?


### PR DESCRIPTION
The same compiled release that have the same version are generating different sha1 sums. This causes the deploy jobs of the cpi pipelines to fail since the sha1 sums do not match.