### PR TITLE
Remove vestiges of the bosh `registry`

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,6 @@ Please ensure you have security groups setup correctly. i.e:
 
 ```
 Type                 Protocol Port Range  Source                     Purpose
-SSH                  TCP      22          <IP you run bosh CLI from> SSH (if Registry is used)
 Custom TCP Rule      TCP      6868        <IP you run bosh CLI from> Agent for bootstrapping
 Custom TCP Rule      TCP      25555       <IP you run bosh CLI from> Director API
 Custom TCP Rule      TCP      8443        <IP you run bosh CLI from> UAA API (if UAA is used)
@@ -91,5 +90,4 @@ Custom TCP Rule      TCP      8844        <IP you run bosh CLI from> CredHub API
 SSH                  TCP      22          <((internal_cidr))>        BOSH SSH (optional)
 Custom TCP Rule      TCP      4222        <((internal_cidr))>        NATS
 Custom TCP Rule      TCP      25250       <((internal_cidr))>        Blobstore
-Custom TCP Rule      TCP      25777       <((internal_cidr))>        Registry if enabled
 ```

--- a/experimental/registry-db-enable-tls.yml
+++ b/experimental/registry-db-enable-tls.yml
@@ -1,6 +1,0 @@
-- type: replace
-  path: /instance_groups/name=bosh/properties/registry/db/tls?
-  value:
-    enabled: true
-    cert:
-      ca: ((db_ca))

--- a/misc/external-db.yml
+++ b/misc/external-db.yml
@@ -19,13 +19,3 @@
     password: ((external_db_password))
     adapter: ((external_db_adapter))
     database: ((external_db_name))
-
-- type: replace
-  path: /instance_groups/name=bosh/properties/registry?/db
-  value:
-    host: ((external_db_host))
-    port: ((external_db_port))
-    user: ((external_db_user))
-    password: ((external_db_password))
-    adapter: ((external_db_adapter))
-    database: ((external_db_name))

--- a/softlayer/cpi-dynamic.yml
+++ b/softlayer/cpi-dynamic.yml
@@ -123,37 +123,9 @@
 - type: replace
   path: /variables/name=blobstore_server_tls/options/alternative_names?/-
   value: "127.0.0.1"
-  
-# Enable registry job
-- type: replace
-  path: /instance_groups/name=bosh/jobs/-
-  value:
-    name: registry
-    release: bosh
-
-- type: replace
-  path: /instance_groups/name=bosh/properties/registry?
-  value:
-    address: ((internal_ip))
-    host: ((internal_ip))
-    db: # todo remove
-      host: 127.0.0.1
-      user: postgres
-      password: ((postgres_password))
-      database: bosh
-      adapter: postgres
-    username: registry
-    password: ((registry_password))
-    port: 25777
 
 - type: replace
   path: /variables/-
   value:
     name: sl_sshkey
     type: ssh
-
-- type: replace
-  path: /variables/-
-  value:
-    name: registry_password
-    type: password

--- a/softlayer/cpi.yml
+++ b/softlayer/cpi.yml
@@ -121,36 +121,8 @@
   path: /variables/name=blobstore_server_tls/options/alternative_names/-
   value: "127.0.0.1"
   
-# Enable registry job
-- type: replace
-  path: /instance_groups/name=bosh/jobs/-
-  value:
-    name: registry
-    release: bosh
-
-- type: replace
-  path: /instance_groups/name=bosh/properties/registry?
-  value:
-    address: ((internal_ip))
-    host: ((internal_ip))
-    db: # todo remove
-      host: 127.0.0.1
-      user: postgres
-      password: ((postgres_password))
-      database: bosh
-      adapter: postgres
-    username: registry
-    password: ((registry_password))
-    port: 25777
-
 - type: replace
   path: /variables/-
   value:
     name: sl_sshkey
     type: ssh
-
-- type: replace
-  path: /variables/-
-  value:
-    name: registry_password
-    type: password


### PR DESCRIPTION
This capability hasn't been supported for several years now, no ops-files should be referencing it.

