### PR TITLE
Disable garden's containerd_mode for bosh lite

### DIFF
--- a/bosh-lite.yml
+++ b/bosh-lite.yml
@@ -23,6 +23,7 @@
   type: replace
   value:
     allow_host_access: true
+    containerd_mode: false
     debug_listen_address: 127.0.0.1:17013
     default_container_grace_time: 0
     destroy_containers_on_start: true


### PR DESCRIPTION
We've had reports such as
https://github.com/cloudfoundry/bpm-release/issues/176 where running bosh lite with the latest runc will fail to deploy or restart.  While we haven't been able to find an absolute root cause, it is the case that garden-runc-release switched the default of this property a few months back: https://github.com/cloudfoundry/garden-runc-release/issues/315.

Garden has some issues with running itself under bpm (see https://github.com/cloudfoundry/garden-runc-release/blob/develop/docs/BPM_support.md) So we postulate that doing the reverse (running bpm under Garden) has some similar issues.

We have not been able to reproduce the issue in
https://github.com/cloudfoundry/bpm-release/issues/176 with containerd_mode set to false.