### PR TITLE
Update default GCP BOSH Lite VM Type

### DIFF
--- a/gcp/bosh-lite-vm-type.yml
+++ b/gcp/bosh-lite-vm-type.yml
@@ -2,4 +2,4 @@
 # Configure sizes for bosh-lite on gcp
 - type: replace
   path: /resource_pools/name=vms/cloud_properties/machine_type
-  value: n1-standard-8
+  value: e2-standard-8


### PR DESCRIPTION
The e2 series is more cost-effective and offers similar performance to the n1 series VM we were using previously.

In my testing I was able to run the CAPI subset of CATS with 12 nodes against this configuration without failures. Additionally this machine type took around the same time to provision and deploy cf-deployment to. I'm currently using it for CAPI's BOSH Lites here: https://github.com/cloudfoundry/capi-ci/pull/127

![Screenshot 2025-04-15 at 9 55 12 AM](https://github.com/user-attachments/assets/ac4767da-d3cf-44a4-9687-d1a774bda3bc)
