### PR TITLE
bosh-monitor and bosh-nats-sync use director address

### DIFF
--- a/bosh.yml
+++ b/bosh.yml
@@ -63,7 +63,7 @@ instance_groups:
           certificate: ((blobstore_server_tls.certificate))
           private_key: ((blobstore_server_tls.private_key))
     director:
-      address: 127.0.0.1
+      address: ((internal_ip))
       db:
         adapter: postgres
         database: bosh

--- a/misc/ipv6/bosh.yml
+++ b/misc/ipv6/bosh.yml
@@ -25,6 +25,10 @@
   value: "nats://[((internal_ip))]:4222"
 
 - type: replace
+  path: /instance_groups/name=bosh/properties/director/address?
+  value: "[((internal_ip))]"
+
+- type: replace
   path: /instance_groups/name=bosh/properties/blobstore/address
   value: "[((internal_ip))]"
 


### PR DESCRIPTION
Previously these jobs connected to the director on localhost which complicates TLS verification. This commit changes these jobs to use the bosh-director's configured address.

Note: Please create PR's against the develop branch