### PR TITLE
Deploy director with UAA and CredHub in docker CPI test

### DIFF
--- a/ci/tasks/test-main-docker-cpi.sh
+++ b/ci/tasks/test-main-docker-cpi.sh
@@ -13,7 +13,9 @@ cp -r "${PWD}/bosh-deployment" "/usr/local/bosh-deployment"
 export USE_LOCAL_RELEASES=false
 
 # shellcheck source=/dev/null
-source start-bosh
+source start-bosh \
+  -o /usr/local/bosh-deployment/uaa.yml \
+  -o /usr/local/bosh-deployment/credhub.yml
 # shellcheck source=/dev/null
 source /tmp/local-bosh/director/bosh-env
 


### PR DESCRIPTION
The bosh-dns runtime config requires a CredHub config server to generate TLS certificate variables. Pass uaa.yml and credhub.yml ops files to start-bosh so the director is deployed with config_server enabled.

Note: Please create PR's against the develop branch