### PR TITLE
Add noble DNS ops file for warden/bosh-lite deployments

### DIFF
--- a/ci/tasks/test-main-docker-cpi.sh
+++ b/ci/tasks/test-main-docker-cpi.sh
@@ -24,7 +24,8 @@ SHA1=$(cat stemcell/sha1)
 
 bosh upload-stemcell --sha1 "$SHA1" "$URL"
 
-bosh -n update-runtime-config "${bosh_deployment}/runtime-configs/dns.yml"
+bosh -n update-runtime-config "${bosh_deployment}/runtime-configs/dns.yml" \
+  --ops-file "${bosh_deployment}/warden/noble-dns.yml"
 
 echo "-----> $(date): Deploy"
 bosh -n -d zookeeper deploy "${bosh_deployment}/ci/assets/zookeeper.yml"

--- a/ci/tasks/test-main-warden-cpi.sh
+++ b/ci/tasks/test-main-warden-cpi.sh
@@ -22,7 +22,8 @@ SHA1=$(cat stemcell/sha1)
 
 bosh upload-stemcell --sha1 "$SHA1" "$URL"
 
-bosh -n update-runtime-config "${bosh_deployment}/runtime-configs/dns.yml"
+bosh -n update-runtime-config "${bosh_deployment}/runtime-configs/dns.yml" \
+  --ops-file "${bosh_deployment}/warden/noble-dns.yml"
 
 echo "-----> $(date): Deploy"
 bosh -n -d zookeeper deploy "${bosh_deployment}/ci/assets/zookeeper.yml"

--- a/virtualbox/create-env.sh
+++ b/virtualbox/create-env.sh
@@ -101,6 +101,7 @@ STEP "Updating Runtime Config"
 ####
 
 bosh -n update-runtime-config "${bosh_deployment}/runtime-configs/dns.yml" \
+  --ops-file "${bosh_deployment}/warden/noble-dns.yml" \
   > /dev/null
 
 echo Succeeded

--- a/warden/noble-dns.yml
+++ b/warden/noble-dns.yml
@@ -1,0 +1,18 @@
+---
+# Overrides bosh-dns configuration for ubuntu-noble on warden/bosh-lite.
+#
+# On non-warden noble VMs, disable_recursors=true is correct — systemd-resolved
+# handles external DNS via DHCP-provided upstream (e.g. 169.254.169.254 on GCP).
+#
+# On warden containers there is no physical NIC and no DHCP, so systemd-resolved
+# has no global upstream. bosh-dns must handle external resolution directly via
+# an explicit recursor. 169.254.169.254 is the link-local metadata DNS available
+# on GCP, AWS, and Azure.
+- type: replace
+  path: /addons/name=bosh-dns-systemd/jobs/name=bosh-dns/properties/disable_recursors
+  value: false
+
+- type: replace
+  path: /addons/name=bosh-dns-systemd/jobs/name=bosh-dns/properties/recursors?
+  value:
+  - 169.254.169.254


### PR DESCRIPTION
On warden containers, systemd-resolved has no DHCP-provided upstream DNS because warden does not configure DNS in the container network namespace. With disable_recursors=true (the noble default), all external DNS queries fail with REFUSED or SERVFAIL.

Add warden/noble-dns.yml which overrides the bosh-dns-systemd addon to:
- set disable_recursors=false so bosh-dns forwards external queries
- set recursors=[169.254.169.254] as the explicit upstream (the link-local metadata DNS available on GCP, AWS and Azure)

Apply the ops file in virtualbox/create-env.sh and both warden/docker CI tasks which deploy noble stemcells on warden.

Note: Please create PR's against the develop branch