### PR TITLE
make warden CPI work with bosh director workers under bpm

### DIFF
--- a/bosh-lite.yml
+++ b/bosh-lite.yml
@@ -38,6 +38,13 @@
 - path: /instance_groups/name=bosh/properties/director/cpi_job?
   type: replace
   value: warden_cpi
+- path: /instance_groups/name=bosh/properties/director/cpi_additional_volumes?
+  type: replace
+  value:
+  - path: /var/vcap/store/warden_cpi
+    writable: true
+    shared: true
+    allow_executions: true
 - path: /instance_groups/name=bosh/properties/warden_cpi?
   type: replace
   value:


### PR DESCRIPTION
This change requires the warden-cpi to make /var/vcap/store/warden_cpi in pre-start so bpm can bind mount it in when the job starts.