### PR TITLE
turn off director worker bpm when using warden cpi

### DIFF
--- a/bosh-lite.yml
+++ b/bosh-lite.yml
@@ -73,6 +73,9 @@
 - path: /instance_groups/name=bosh/properties/director/ignore_missing_gateway?
   type: replace
   value: true
+- path: /instance_groups/name=bosh/properties/director/use_bpm_for_workers?
+  type: replace
+  value: false
 - path: /instance_groups/name=bosh/properties/compiled_package_cache?
   type: replace
   value:

--- a/warden/cpi.yml
+++ b/warden/cpi.yml
@@ -43,3 +43,6 @@
     warden:
       connect_address: ((garden_host)):7777
       connect_network: tcp
+- path: /instance_groups/name=bosh/properties/director/use_bpm_for_workers?
+  type: replace
+  value: false


### PR DESCRIPTION
the warden cpi does not work when run under BPM, so set the bosh property to disable it.

https://github.com/cloudfoundry/bosh/pull/2771

