### PR TITLE
Add Proxmox VE CPI support with local and CI deployment

### DIFF
--- a/.github/workflows/proxmox-deploy.yml
+++ b/.github/workflows/proxmox-deploy.yml
@@ -1,0 +1,98 @@
+# Deploy / update / delete THIS environment's BOSH director on Proxmox VE, using
+# the PUBLISHED bosh-proxmox-cpi release (no source build). Runs on the
+# self-hosted 'proxmox-cpi' runner (must reach the Proxmox API and the director
+# IP). state.json + creds.yml are persisted to Ceph S3 via
+# deployments/proxmox/deploy.sh, so the director survives across runs.
+#
+# Config is split so non-sensitive values stay visible/editable and creds stay hidden.
+# Seed both with defaults via: deployments/proxmox/seed-github-config.sh
+#
+# Repository VARIABLES (Settings -> Secrets and variables -> Actions -> Variables):
+#   PROXMOX_API_URL PROXMOX_NODE PROXMOX_VM_STORAGE PROXMOX_IMPORT_STORAGE
+#   PROXMOX_BRIDGE PROXMOX_INSECURE_SKIP_VERIFY DIRECTOR_NAME
+#   DIRECTOR_INTERNAL_CIDR DIRECTOR_INTERNAL_GW DIRECTOR_INTERNAL_IP
+#   STATE_S3_BUCKET STATE_S3_PREFIX AWS_S3_ENDPOINT AWS_DEFAULT_REGION
+# Repository SECRETS (sensitive — replace the seeded placeholders with real values):
+#   PROXMOX_API_TOKEN AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
+name: proxmox-deploy
+
+on:
+  workflow_dispatch:
+    inputs:
+      action:
+        description: "deploy (create/update) or delete the director"
+        type: choice
+        options: [deploy, delete]
+        default: deploy
+      cpi_release_version:
+        description: "Published CPI version to deploy"
+        default: "1.0.0"
+      cpi_release_sha1:
+        description: "SHA1 of the published CPI tarball"
+        default: "facc1ef0af0e421508b2db5f86f82b3726f4e030"
+      cpi_release_url:
+        description: "CPI tarball URL (blank = GitHub release URL)"
+        default: "https://cdn.cf-apps.io/bosh-proxmox-cpi-1.0.0.tgz"
+      upload_cloud_config:
+        description: "Apply proxmox/cloud-config.yml after deploy"
+        type: boolean
+        default: true
+      upload_stemcell:
+        description: "Upload a stemcell after deploy"
+        type: boolean
+        default: false
+
+# Never let two operations run against the same state at once.
+concurrency:
+  group: proxmox-deploy
+  cancel-in-progress: false
+
+jobs:
+  director:
+    runs-on: proxmox-cpi
+    env:
+      BOSH_CLI_VERSION: "7.9.9"
+    steps:
+    - name: Checkout bosh-deployment (this fork)
+      uses: actions/checkout@v4
+
+    - name: Install bosh CLI
+      run: |
+        curl -fsSL -o bosh "https://github.com/cloudfoundry/bosh-cli/releases/download/v${BOSH_CLI_VERSION}/bosh-cli-${BOSH_CLI_VERSION}-linux-amd64"
+        chmod +x bosh
+        sudo mv bosh /usr/local/bin/bosh
+        bosh --version
+
+    - name: Ensure aws CLI (for S3 state sync)
+      run: |
+        if command -v aws >/dev/null 2>&1; then aws --version; exit 0; fi
+        curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o /tmp/awscliv2.zip
+        (cd /tmp && unzip -q awscliv2.zip && sudo ./aws/install)
+        aws --version
+
+    - name: Deploy / update / delete the director
+      env:
+        ACTION:                 ${{ inputs.action || 'deploy' }}
+        CPI_RELEASE_VERSION:    ${{ inputs.cpi_release_version }}
+        CPI_RELEASE_SHA1:       ${{ inputs.cpi_release_sha1 }}
+        CPI_RELEASE_URL:        ${{ inputs.cpi_release_url }}
+        PROXMOX_API_URL:        ${{ vars.PROXMOX_API_URL }}
+        PROXMOX_API_TOKEN:      ${{ secrets.PROXMOX_API_TOKEN }}
+        PROXMOX_NODE:           ${{ vars.PROXMOX_NODE }}
+        PROXMOX_VM_STORAGE:     ${{ vars.PROXMOX_VM_STORAGE }}
+        PROXMOX_IMPORT_STORAGE: ${{ vars.PROXMOX_IMPORT_STORAGE }}
+        PROXMOX_BRIDGE:         ${{ vars.PROXMOX_BRIDGE || 'vmbr0' }}
+        PROXMOX_INSECURE_SKIP_VERIFY: ${{ vars.PROXMOX_INSECURE_SKIP_VERIFY || 'true' }}
+        DIRECTOR_NAME:          ${{ vars.DIRECTOR_NAME || 'bosh-proxmox' }}
+        DIRECTOR_INTERNAL_CIDR: ${{ vars.DIRECTOR_INTERNAL_CIDR }}
+        DIRECTOR_INTERNAL_GW:   ${{ vars.DIRECTOR_INTERNAL_GW }}
+        DIRECTOR_INTERNAL_IP:   ${{ vars.DIRECTOR_INTERNAL_IP }}
+        STATE_S3_BUCKET:        ${{ vars.STATE_S3_BUCKET }}
+        STATE_S3_PREFIX:        ${{ vars.STATE_S3_PREFIX || 'director' }}
+        AWS_S3_ENDPOINT:        ${{ vars.AWS_S3_ENDPOINT }}
+        AWS_ACCESS_KEY_ID:      ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY:  ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        AWS_DEFAULT_REGION:     ${{ vars.AWS_DEFAULT_REGION || 'us-east-1' }}
+        UPLOAD_CLOUD_CONFIG:    ${{ inputs.upload_cloud_config && 'true' || '' }}
+        UPLOAD_STEMCELL:        ${{ inputs.upload_stemcell && 'true' || '' }}
+      run: ./deployments/proxmox/deploy.sh

--- a/.github/workflows/proxmox-director.yml
+++ b/.github/workflows/proxmox-director.yml
@@ -1,0 +1,105 @@
+# Deploy / update / delete the BOSH director on Proxmox VE via CI.
+#
+# Runs on the self-hosted 'proxmox-cpi' runner (the same one the CPI repo uses),
+# which must be able to reach the Proxmox API and the director's IP. State
+# (state.json + creds.yml) is persisted to S3-compatible object storage so the
+# director survives across runs — see proxmox/ci-deploy.sh.
+#
+# Required repository secrets:
+#   PROXMOX_API_URL PROXMOX_API_TOKEN PROXMOX_NODE
+#   PROXMOX_VM_STORAGE PROXMOX_IMPORT_STORAGE PROXMOX_BRIDGE
+#   DIRECTOR_INTERNAL_CIDR DIRECTOR_INTERNAL_GW DIRECTOR_INTERNAL_IP
+#   STATE_S3_BUCKET AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
+# Optional secrets/vars:
+#   PROXMOX_INSECURE_SKIP_VERIFY  AWS_DEFAULT_REGION  AWS_S3_ENDPOINT (MinIO)
+#   DIRECTOR_NAME  STATE_S3_PREFIX
+name: proxmox-director
+
+on:
+  workflow_dispatch:
+    inputs:
+      action:
+        description: "deploy (create/update) or delete the director"
+        type: choice
+        options: [deploy, delete]
+        default: deploy
+      upload_cloud_config:
+        description: "Apply proxmox/cloud-config.yml after deploy"
+        type: boolean
+        default: true
+      upload_stemcell:
+        description: "Upload a stemcell after deploy"
+        type: boolean
+        default: false
+  push:
+    branches: [master]
+    paths:
+      - proxmox/**
+      - bosh.yml
+      - .github/workflows/proxmox-director.yml
+
+# Never let two director operations run against the same state at once.
+concurrency:
+  group: proxmox-director
+  cancel-in-progress: false
+
+jobs:
+  director:
+    runs-on: proxmox-cpi
+    env:
+      BOSH_CLI_VERSION: "7.9.9"
+    steps:
+    - name: Checkout bosh-deployment (this fork)
+      uses: actions/checkout@v4
+
+    - name: Checkout bosh-proxmox-cpi
+      uses: actions/checkout@v4
+      with:
+        repository: hjaffan/bosh-proxmox-cpi
+        path: bosh-proxmox-cpi
+        # If the CPI repo is private, add a PAT here:
+        # token: ${{ secrets.CPI_REPO_TOKEN }}
+
+    - uses: actions/setup-go@v5
+      with:
+        go-version: stable
+        cache: false
+
+    - name: Install bosh CLI
+      run: |
+        curl -fsSL -o bosh "https://github.com/cloudfoundry/bosh-cli/releases/download/v${BOSH_CLI_VERSION}/bosh-cli-${BOSH_CLI_VERSION}-linux-amd64"
+        chmod +x bosh
+        sudo mv bosh /usr/local/bin/bosh
+        bosh --version
+
+    - name: Ensure aws CLI (for S3 state sync)
+      run: |
+        if command -v aws >/dev/null 2>&1; then aws --version; exit 0; fi
+        curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o /tmp/awscliv2.zip
+        (cd /tmp && unzip -q awscliv2.zip && sudo ./aws/install)
+        aws --version
+
+    - name: Deploy / update / delete the director
+      env:
+        ACTION:                 ${{ inputs.action || 'deploy' }}
+        PROXMOX_API_URL:        ${{ secrets.PROXMOX_API_URL }}
+        PROXMOX_API_TOKEN:      ${{ secrets.PROXMOX_API_TOKEN }}
+        PROXMOX_NODE:           ${{ secrets.PROXMOX_NODE }}
+        PROXMOX_VM_STORAGE:     ${{ secrets.PROXMOX_VM_STORAGE }}
+        PROXMOX_IMPORT_STORAGE: ${{ secrets.PROXMOX_IMPORT_STORAGE }}
+        PROXMOX_BRIDGE:         ${{ secrets.PROXMOX_BRIDGE }}
+        PROXMOX_INSECURE_SKIP_VERIFY: ${{ secrets.PROXMOX_INSECURE_SKIP_VERIFY || 'true' }}
+        DIRECTOR_NAME:          ${{ secrets.DIRECTOR_NAME || 'bosh-proxmox' }}
+        DIRECTOR_INTERNAL_CIDR: ${{ secrets.DIRECTOR_INTERNAL_CIDR }}
+        DIRECTOR_INTERNAL_GW:   ${{ secrets.DIRECTOR_INTERNAL_GW }}
+        DIRECTOR_INTERNAL_IP:   ${{ secrets.DIRECTOR_INTERNAL_IP }}
+        STATE_S3_BUCKET:        ${{ secrets.STATE_S3_BUCKET }}
+        STATE_S3_PREFIX:        ${{ secrets.STATE_S3_PREFIX || 'director' }}
+        AWS_ACCESS_KEY_ID:      ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY:  ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        AWS_DEFAULT_REGION:     ${{ secrets.AWS_DEFAULT_REGION || 'us-east-1' }}
+        AWS_S3_ENDPOINT:        ${{ secrets.AWS_S3_ENDPOINT }}
+        PROXMOX_CPI_DIR:        ${{ github.workspace }}/bosh-proxmox-cpi
+        UPLOAD_CLOUD_CONFIG:    ${{ (github.event_name == 'push' || inputs.upload_cloud_config) && 'true' || '' }}
+        UPLOAD_STEMCELL:        ${{ inputs.upload_stemcell && 'true' || '' }}
+      run: ./proxmox/ci-deploy.sh

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,6 @@
 
 creds.yml
 
+proxmox/vars.yml
+
 tmp

--- a/deployments/proxmox/.gitignore
+++ b/deployments/proxmox/.gitignore
@@ -1,0 +1,4 @@
+# Environment secrets + deploy state — never commit these.
+vars.yml
+creds.yml
+state.json

--- a/deployments/proxmox/README.md
+++ b/deployments/proxmox/README.md
@@ -1,0 +1,79 @@
+# Proxmox director — my environment
+
+A self-contained BOSH director deployment for this environment on
+[Proxmox VE](https://www.proxmox.com/), using the **published**
+[`bosh-proxmox-cpi`](https://github.com/hjaffan/bosh-proxmox-cpi) **release**
+(no source build). State (`state.json` + `creds.yml`) is persisted to **Ceph S3**.
+
+## Why this is a separate directory
+
+This fork mirrors upstream `cloudfoundry/bosh-deployment`. To keep pulling
+upstream **merge-clean**, everything here is **new files only** — it never edits
+`bosh.yml` or any upstream file. It layers the shared, additive ops files
+(`proxmox/cpi.yml`, `proxmox/use-published-release.yml`,
+`proxmox/cpi-release-url.yml`, `jumpbox-user.yml`) on top via `-o`, read-only.
+
+| File | Purpose |
+|---|---|
+| `deploy.sh` | Driver: `create-env` / `delete-env` / `cloud-config` / `env`, published release, Ceph S3 state |
+| `vars.tmpl.yml` | Copy to `vars.yml` and fill in (Proxmox + networking). Git-ignored. |
+| `.gitignore` | Keeps `vars.yml`, `creds.yml`, `state.json` out of git |
+
+The CPI release is pinned to **v1.0.0** (`https://cdn.cf-apps.io/bosh-proxmox-cpi-1.0.0.tgz`,
+sha1 `facc1ef0…f4e030`) by default — override with `CPI_RELEASE_VERSION` /
+`CPI_RELEASE_SHA1` / `CPI_RELEASE_URL`.
+
+## Deploy locally
+
+```bash
+cp deployments/proxmox/vars.tmpl.yml deployments/proxmox/vars.yml
+$EDITOR deployments/proxmox/vars.yml          # Proxmox + networking
+
+# Ceph S3 (state store) — keys stay out of git; endpoint is your RGW:
+export AWS_S3_ENDPOINT=https://<ceph-rgw>:<port>
+export STATE_S3_BUCKET=<bucket> STATE_S3_PREFIX=director
+export AWS_ACCESS_KEY_ID=… AWS_SECRET_ACCESS_KEY=…
+
+deployments/proxmox/deploy.sh deploy
+eval "$(deployments/proxmox/deploy.sh env)"   # talk to the director
+```
+
+Tear down with `deployments/proxmox/deploy.sh delete`.
+
+## Deploy via CI (self-hosted runner)
+
+`.github/workflows/proxmox-deploy.yml` runs `deploy.sh` on the self-hosted
+**`proxmox-cpi`** runner, `workflow_dispatch` only (no auto-deploy on push — infra
+changes are deliberate). Config is split so it's easy to reason about:
+
+- **Repository Variables** (non-sensitive, visible/editable): `PROXMOX_API_URL`,
+  `PROXMOX_NODE`, `PROXMOX_VM_STORAGE`, `PROXMOX_IMPORT_STORAGE`, `PROXMOX_BRIDGE`,
+  `PROXMOX_INSECURE_SKIP_VERIFY`, `DIRECTOR_NAME`, `DIRECTOR_INTERNAL_CIDR`,
+  `DIRECTOR_INTERNAL_GW`, `DIRECTOR_INTERNAL_IP`, `STATE_S3_BUCKET`,
+  `STATE_S3_PREFIX`, `AWS_S3_ENDPOINT` (your Ceph RGW), `AWS_DEFAULT_REGION`.
+- **Repository Secrets** (sensitive): `PROXMOX_API_TOKEN`, `AWS_ACCESS_KEY_ID`,
+  `AWS_SECRET_ACCESS_KEY` (RGW keys).
+
+**Seed them all with defaults** (variables get real defaults; secrets get
+`CHANGE-ME` placeholders you must replace):
+
+```bash
+deployments/proxmox/seed-github-config.sh                 # -> hjaffan/bosh-deployment
+# then set the real values:
+gh variable set DIRECTOR_INTERNAL_IP -R hjaffan/bosh-deployment --body 10.20.0.6
+gh secret   set PROXMOX_API_TOKEN    -R hjaffan/bosh-deployment
+gh secret   set AWS_ACCESS_KEY_ID    -R hjaffan/bosh-deployment
+gh secret   set AWS_SECRET_ACCESS_KEY -R hjaffan/bosh-deployment
+```
+
+The script is idempotent — it never clobbers an existing value (pass `FORCE=1` to
+overwrite). Also **register the `proxmox-cpi` self-hosted runner** on this repo
+(online, able to reach the Proxmox API and director IP).
+
+Then: Actions → **proxmox-deploy** → Run workflow (or
+`gh workflow run proxmox-deploy.yml -f action=deploy`).
+
+> **`creds.yml` holds the director admin password, the CA private key, and every
+> internal cert/password.** Use a **private** bucket. Uploads try SSE-S3 and fall
+> back to a plain upload if the RGW doesn't offer it — so ensure the bucket/pool
+> is private and encrypted at rest, and the RGW endpoint is TLS.

--- a/deployments/proxmox/deploy.sh
+++ b/deployments/proxmox/deploy.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+# Deploy / update / delete the BOSH director for THIS environment on Proxmox VE,
+# using the PUBLISHED bosh-proxmox-cpi release (no source build), with
+# state.json + creds.yml persisted to Ceph S3 (or any S3-compatible store).
+#
+# This is a self-contained environment deployment. It only READS files that ship
+# in the repo (upstream bosh.yml + jumpbox-user.yml, and the additive
+# proxmox/*.yml ops files) via `-o`/`-l` — it never edits them — so pulling
+# upstream cloudfoundry/bosh-deployment stays merge-clean.
+#
+# Usage:
+#   deployments/proxmox/deploy.sh [deploy|delete|cloud-config|env]
+#     deploy        (default) create-env — bootstrap or update the director
+#     delete        delete-env — tear the director down
+#     cloud-config  upload proxmox/cloud-config.yml to the running director
+#     env           print the BOSH_* env vars to talk to the director (eval it)
+#
+# Configuration comes from EITHER:
+#   * deployments/proxmox/vars.yml   (local; copied from vars.tmpl.yml), or
+#   * environment variables          (CI secrets — see the block below)
+# S3 settings and the release pin always come from the environment.
+#
+# Required env (or provide the proxmox_*/internal_* keys via vars.yml):
+#   PROXMOX_API_URL PROXMOX_API_TOKEN PROXMOX_NODE
+#   PROXMOX_VM_STORAGE PROXMOX_IMPORT_STORAGE
+#   DIRECTOR_INTERNAL_CIDR DIRECTOR_INTERNAL_GW DIRECTOR_INTERNAL_IP
+# Always required (for state persistence):
+#   STATE_S3_BUCKET AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_S3_ENDPOINT
+# Optional env:
+#   ACTION=deploy|delete            (default: the CLI arg, else deploy)
+#   DIRECTOR_NAME                   (default bosh-proxmox)
+#   PROXMOX_BRIDGE                  (default vmbr0)
+#   PROXMOX_INSECURE_SKIP_VERIFY    (default true)
+#   STATE_S3_PREFIX                 (default director)
+#   AWS_DEFAULT_REGION              (default us-east-1)
+#   CPI_RELEASE_VERSION             (default 1.0.0)
+#   CPI_RELEASE_SHA1                (default the v1.0.0 tarball sha1)
+#   CPI_RELEASE_URL                 (default https://cdn.cf-apps.io/...1.0.0.tgz)
+#   UPLOAD_CLOUD_CONFIG=true        after deploy, apply proxmox/cloud-config.yml
+#   UPLOAD_STEMCELL=true            after deploy, upload STEMCELL_URL
+#   STEMCELL_URL                    (default jammy openstack-kvm)
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+root="$(cd "$here/../.." && pwd)"   # repo root — ops files are referenced from here
+cd "$root"
+
+action="${ACTION:-${1:-deploy}}"
+state="$here/state.json"
+creds="$here/creds.yml"
+vars="$here/vars.yml"
+
+# --- published release pin (overridable) --------------------------------------
+CPI_RELEASE_VERSION="${CPI_RELEASE_VERSION:-1.0.0}"
+CPI_RELEASE_SHA1="${CPI_RELEASE_SHA1:-facc1ef0af0e421508b2db5f86f82b3726f4e030}"
+CPI_RELEASE_URL="${CPI_RELEASE_URL:-https://cdn.cf-apps.io/bosh-proxmox-cpi-${CPI_RELEASE_VERSION}.tgz}"
+
+# --- BOSH CLI (Homebrew ships it as "bosh-cli") -------------------------------
+if command -v bosh >/dev/null 2>&1; then bosh=bosh
+elif command -v bosh-cli >/dev/null 2>&1; then bosh=bosh-cli
+else echo "FATAL: the BOSH CLI is not installed (brew install cloudfoundry/tap/bosh-cli)" >&2; exit 2; fi
+
+req() { [ -n "${!1:-}" ] || { echo "FATAL: missing required env var $1" >&2; exit 2; }; }
+
+# --- ops files (read-only; reused, never edited) ------------------------------
+ops=(
+  bosh.yml
+  -o proxmox/cpi.yml
+  -o proxmox/use-published-release.yml
+  -o proxmox/cpi-release-url.yml
+  -o jumpbox-user.yml
+  --state="$state" --vars-store="$creds"
+  -v proxmox_cpi_version="$CPI_RELEASE_VERSION"
+  -v proxmox_cpi_sha1="$CPI_RELEASE_SHA1"
+  -v proxmox_cpi_url="$CPI_RELEASE_URL"
+)
+
+# --- director + proxmox vars: from vars.yml if present, else from env ---------
+if [ -f "$vars" ]; then
+  ops+=( -l "$vars" )
+  director_ip="$("$bosh" int "$vars" --path /internal_ip)"
+else
+  for v in PROXMOX_API_URL PROXMOX_API_TOKEN PROXMOX_NODE PROXMOX_VM_STORAGE \
+           PROXMOX_IMPORT_STORAGE DIRECTOR_INTERNAL_CIDR DIRECTOR_INTERNAL_GW \
+           DIRECTOR_INTERNAL_IP; do req "$v"; done
+  director_ip="$DIRECTOR_INTERNAL_IP"
+  ops+=(
+    -v director_name="${DIRECTOR_NAME:-bosh-proxmox}"
+    -v internal_cidr="$DIRECTOR_INTERNAL_CIDR"
+    -v internal_gw="$DIRECTOR_INTERNAL_GW"
+    -v internal_ip="$DIRECTOR_INTERNAL_IP"
+    -v proxmox_api_url="$PROXMOX_API_URL"
+    -v proxmox_api_token="$PROXMOX_API_TOKEN"
+    -v proxmox_node="$PROXMOX_NODE"
+    -v proxmox_vm_storage="$PROXMOX_VM_STORAGE"
+    -v proxmox_import_storage="$PROXMOX_IMPORT_STORAGE"
+    -v proxmox_bridge="${PROXMOX_BRIDGE:-vmbr0}"
+    -v proxmox_insecure_skip_verify="${PROXMOX_INSECURE_SKIP_VERIFY:-true}"
+  )
+fi
+
+# --- S3 (Ceph RGW) state store ------------------------------------------------
+export AWS_DEFAULT_REGION="${AWS_DEFAULT_REGION:-us-east-1}"
+STATE_S3_PREFIX="${STATE_S3_PREFIX:-director}"
+aws_s3() { aws ${AWS_S3_ENDPOINT:+--endpoint-url "$AWS_S3_ENDPOINT"} s3 "$@"; }
+s3_uri="s3://${STATE_S3_BUCKET:-}/$STATE_S3_PREFIX"
+
+# push a file to S3: try SSE-S3, fall back to plain upload, fail LOUD (never
+# silently drop creds/state — that is the whole point of this step).
+put() {
+  local f="$1" name; name="$(basename "$f")"
+  [ -f "$f" ] || return 0
+  if aws_s3 cp "$f" "$s3_uri/$name" --sse AES256 2>/dev/null; then echo "  pushed $name (SSE-S3)"; return 0; fi
+  echo "  note: SSE-S3 rejected for $name; retrying without --sse (bucket/pool must be private + encrypted at rest)" >&2
+  if aws_s3 cp "$f" "$s3_uri/$name"; then echo "  pushed $name"; return 0; fi
+  echo "  ERROR: failed to upload $name to $s3_uri/ — STATE NOT PERSISTED" >&2
+  return 1
+}
+
+# --- director BOSH_* env (for verify / cloud-config / env action) -------------
+director_env() {
+  cat <<EOF
+export BOSH_ENVIRONMENT=$director_ip
+export BOSH_CLIENT=admin
+export BOSH_CLIENT_SECRET=$("$bosh" int "$creds" --path /admin_password)
+export BOSH_CA_CERT="$("$bosh" int "$creds" --path /director_ssl/ca)"
+EOF
+}
+
+case "$action" in
+  deploy|delete)
+    req STATE_S3_BUCKET; req AWS_ACCESS_KEY_ID; req AWS_SECRET_ACCESS_KEY; req AWS_S3_ENDPOINT
+
+    echo "== pulling existing state from $s3_uri =="
+    aws_s3 cp "$s3_uri/state.json" "$state" 2>/dev/null || echo "  no existing state.json (first run)"
+    aws_s3 cp "$s3_uri/creds.yml"  "$creds" 2>/dev/null || echo "  no existing creds.yml (first run)"
+
+    # Always push state back — even on a partial create-env failure, so a
+    # half-created director VM recorded in state.json is never orphaned.
+    push_state() {
+      echo "== pushing state to $s3_uri =="
+      put "$state" || true
+      put "$creds" || true
+      if [ "$action" = delete ] && [ ! -f "$state" ]; then
+        aws_s3 rm "$s3_uri/state.json" 2>/dev/null || true
+        aws_s3 rm "$s3_uri/creds.yml"  2>/dev/null || true
+      fi
+    }
+    trap push_state EXIT
+
+    if [ "$action" = delete ]; then
+      echo "== delete-env: tearing down the director =="
+      "$bosh" delete-env "${ops[@]}"
+      echo "DIRECTOR DELETED"
+      exit 0
+    fi
+
+    echo "== create-env: deploying CPI v$CPI_RELEASE_VERSION director at $director_ip =="
+    "$bosh" create-env "${ops[@]}"
+
+    echo "== verifying the director responds =="
+    eval "$(director_env)"
+    "$bosh" -e "$director_ip" env
+
+    if [ "${UPLOAD_CLOUD_CONFIG:-}" = true ]; then
+      echo "== applying cloud-config =="
+      if [ -f "$vars" ]; then
+        "$bosh" -n update-cloud-config proxmox/cloud-config.yml -l "$vars"
+      else
+        "$bosh" -n update-cloud-config proxmox/cloud-config.yml \
+          -v internal_cidr="$DIRECTOR_INTERNAL_CIDR" \
+          -v internal_gw="$DIRECTOR_INTERNAL_GW" \
+          -v proxmox_bridge="${PROXMOX_BRIDGE:-vmbr0}"
+      fi
+    fi
+
+    if [ "${UPLOAD_STEMCELL:-}" = true ]; then
+      echo "== uploading stemcell =="
+      "$bosh" -n upload-stemcell "${STEMCELL_URL:-https://bosh.io/d/stemcells/bosh-openstack-kvm-ubuntu-jammy-go_agent}"
+    fi
+
+    echo
+    echo "============================================================"
+    echo "DIRECTOR DEPLOYED — $director_ip (CPI v$CPI_RELEASE_VERSION)"
+    echo "state + creds persisted to $s3_uri/"
+    echo "============================================================"
+    ;;
+
+  cloud-config)
+    [ -f "$creds" ] || { echo "ERROR: $creds missing — deploy first." >&2; exit 1; }
+    eval "$(director_env)"
+    if [ -f "$vars" ]; then
+      "$bosh" -n update-cloud-config proxmox/cloud-config.yml -l "$vars"
+    else
+      "$bosh" -n update-cloud-config proxmox/cloud-config.yml \
+        -v internal_cidr="$DIRECTOR_INTERNAL_CIDR" \
+        -v internal_gw="$DIRECTOR_INTERNAL_GW" \
+        -v proxmox_bridge="${PROXMOX_BRIDGE:-vmbr0}"
+    fi
+    ;;
+
+  env)
+    [ -f "$creds" ] || { echo "ERROR: $creds missing — deploy first." >&2; exit 1; }
+    director_env
+    ;;
+
+  *)
+    echo "Unknown action: $action (use deploy|delete|cloud-config|env)" >&2
+    exit 1
+    ;;
+esac

--- a/deployments/proxmox/seed-github-config.sh
+++ b/deployments/proxmox/seed-github-config.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Seed the GitHub Actions config the proxmox-deploy workflow needs, with safe
+# DEFAULTS, so the repo is wired up before you have real values.
+#
+#   - Non-sensitive config  -> repository VARIABLES (visible, edit in the UI later)
+#   - Sensitive credentials -> repository SECRETS   (seeded as CHANGE-ME placeholders)
+#
+# Idempotent: an existing variable/secret is left ALONE (never clobbered), so
+# re-running after you've set real values is safe. Pass FORCE=1 to overwrite.
+#
+# Usage:
+#   deployments/proxmox/seed-github-config.sh                 # seed hjaffan/bosh-deployment
+#   REPO=owner/repo deployments/proxmox/seed-github-config.sh # a different repo
+#   FORCE=1 deployments/proxmox/seed-github-config.sh         # overwrite existing
+#
+# Requires the gh CLI, authenticated with repo admin on REPO.
+set -euo pipefail
+
+REPO="${REPO:-hjaffan/bosh-deployment}"
+FORCE="${FORCE:-0}"
+
+command -v gh >/dev/null 2>&1 || { echo "FATAL: gh CLI not found" >&2; exit 2; }
+
+# name = default  (non-sensitive -> Actions Variables)
+variables=(
+  "PROXMOX_API_URL=https://pve.example.com:8006"
+  "PROXMOX_NODE=pve1"
+  "PROXMOX_VM_STORAGE=local-lvm"
+  "PROXMOX_IMPORT_STORAGE=local"
+  "PROXMOX_BRIDGE=vmbr0"
+  "PROXMOX_INSECURE_SKIP_VERIFY=true"     # self-signed PVE cert -> do not validate
+  "DIRECTOR_NAME=bosh-proxmox"
+  "DIRECTOR_INTERNAL_CIDR=10.0.0.0/24"
+  "DIRECTOR_INTERNAL_GW=10.0.0.1"
+  "DIRECTOR_INTERNAL_IP=10.0.0.6"
+  "STATE_S3_BUCKET=bosh-director-state"
+  "STATE_S3_PREFIX=director"
+  "AWS_S3_ENDPOINT=https://ceph-rgw.example.com"   # your Ceph RGW endpoint
+  "AWS_DEFAULT_REGION=us-east-1"
+)
+
+# name = placeholder  (sensitive -> Actions Secrets; REPLACE these with real values)
+secrets=(
+  "PROXMOX_API_TOKEN=bosh@pve!cpi=CHANGE-ME"
+  "AWS_ACCESS_KEY_ID=CHANGE-ME"
+  "AWS_SECRET_ACCESS_KEY=CHANGE-ME"
+)
+
+existing_vars="$(gh variable list -R "$REPO" 2>/dev/null | awk 'NF{print $1}' || true)"
+existing_secrets="$(gh secret list  -R "$REPO" 2>/dev/null | awk 'NF{print $1}' || true)"
+has() { printf '%s\n' "$2" | grep -qx "$1"; }
+
+echo "== seeding repository VARIABLES on $REPO =="
+for kv in "${variables[@]}"; do
+  name="${kv%%=*}"; value="${kv#*=}"
+  if [ "$FORCE" != 1 ] && has "$name" "$existing_vars"; then
+    echo "  = $name (exists — kept)"; continue
+  fi
+  gh variable set "$name" -R "$REPO" --body "$value" && echo "  + $name = $value"
+done
+
+echo "== seeding repository SECRETS on $REPO (placeholders — replace before deploying) =="
+for kv in "${secrets[@]}"; do
+  name="${kv%%=*}"; value="${kv#*=}"
+  if [ "$FORCE" != 1 ] && has "$name" "$existing_secrets"; then
+    echo "  = $name (exists — kept)"; continue
+  fi
+  gh secret set "$name" -R "$REPO" --body "$value" && echo "  + $name = <placeholder>"
+done
+
+cat <<EOF
+
+Done. Next:
+  1. Edit the VARIABLES with your real values (Settings -> Secrets and variables
+     -> Actions -> Variables), or re-run any single one, e.g.:
+       gh variable set DIRECTOR_INTERNAL_IP -R $REPO --body 10.20.0.6
+  2. Replace the three SECRETS with real credentials:
+       gh secret set PROXMOX_API_TOKEN     -R $REPO
+       gh secret set AWS_ACCESS_KEY_ID     -R $REPO
+       gh secret set AWS_SECRET_ACCESS_KEY -R $REPO
+  The workflow will fail fast against the CHANGE-ME placeholders until you do.
+EOF

--- a/deployments/proxmox/vars.tmpl.yml
+++ b/deployments/proxmox/vars.tmpl.yml
@@ -1,0 +1,25 @@
+# Deployment variables for THIS environment's Proxmox BOSH director.
+#
+#   cp deployments/proxmox/vars.tmpl.yml deployments/proxmox/vars.yml
+#   # then fill in the values below
+#
+# vars.yml is git-ignored (it holds your API token). S3 credentials do NOT go
+# here — export them / set them as CI secrets. The CPI release pin is not here
+# either; it defaults to the published v1.0.0 (override with CPI_RELEASE_* env).
+---
+# --- Director identity & networking (the director VM's static IP on your LAN) ---
+director_name: bosh-proxmox
+internal_cidr: 10.0.0.0/24     # subnet the director lives on
+internal_gw: 10.0.0.1          # gateway for that subnet
+internal_ip: 10.0.0.6          # static IP to assign the director VM
+
+# --- Proxmox API connection ---
+proxmox_api_url: https://pve.example.com:8006
+proxmox_api_token: "bosh@pve!cpi=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+proxmox_insecure_skip_verify: true   # true if the PVE API cert is self-signed
+
+# --- Proxmox placement & storage ---
+proxmox_node: pve1             # node name to create the director on
+proxmox_vm_storage: local-lvm  # storage for VM disks (content: images)
+proxmox_import_storage: local  # storage with content: import AND iso enabled
+proxmox_bridge: vmbr0          # Linux bridge / SDN vnet for the default network

--- a/proxmox/README.md
+++ b/proxmox/README.md
@@ -1,0 +1,109 @@
+# Proxmox VE
+
+Deploy a BOSH director onto [Proxmox VE](https://www.proxmox.com/) using the
+[bosh-proxmox-cpi](https://github.com/hjaffan/bosh-proxmox-cpi). Proxmox is not
+an official BOSH CPI, so these ops files are vendored into this fork from that
+repo's `manifests/`.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `cpi.yml` | Ops file that wires the Proxmox CPI into the repo's `bosh.yml` |
+| `cloud-config.yml` | Example cloud config (AZs, vm_types, networks, disks) |
+| `use-published-release.yml` | Use a published CPI tarball instead of a local checkout |
+| `vars.tmpl.yml` | Template for your deployment variables — copy to `vars.yml` and fill in |
+| `deploy.sh` | Local wrapper around `bosh create-env` / `delete-env` / cloud-config |
+| `ci-deploy.sh` | CI entrypoint — same, but reads secrets from env and persists state to S3 |
+
+`vars.yml`, `creds.yml`, and `state.json` are git-ignored (they hold secrets and
+deploy state).
+
+## Prerequisites
+
+1. **Proxmox VE 8.4+** with an API token (`bosh@pve!cpi=...`) and storages with
+   `import`+`iso` content (e.g. `local`) and VM disks (e.g. `local-lvm`). See
+   the CPI's `docs/proxmox-setup.md`.
+2. **BOSH CLI** — `brew install cloudfoundry/tap/bosh-cli`
+   (or https://github.com/cloudfoundry/bosh-cli/releases).
+3. **A checkout of `bosh-proxmox-cpi`** next to this repo (`../bosh-proxmox-cpi`),
+   or point `PROXMOX_CPI_DIR` at it. No published release exists yet, so the CPI
+   is built from the checkout (`deploy.sh` vendors the Go package automatically
+   on first run).
+
+## Deploy
+
+```bash
+# 1. Fill in your environment (first run creates vars.yml from the template)
+proxmox/deploy.sh            # -> writes proxmox/vars.yml, then edit it
+$EDITOR proxmox/vars.yml
+
+# 2. Bootstrap the director (create-env)
+proxmox/deploy.sh deploy
+
+# 3. Point the CLI at it, upload cloud config + a stemcell
+eval "$(proxmox/deploy.sh env)"
+proxmox/deploy.sh cloud-config
+bosh upload-stemcell https://bosh.io/d/stemcells/bosh-openstack-kvm-ubuntu-jammy-go_agent
+
+# 4. Deploy something
+bosh -d zookeeper deploy <(curl -sL https://raw.githubusercontent.com/cppforlife/zookeeper-release/master/manifests/zookeeper.yml)
+```
+
+Tear down with `proxmox/deploy.sh delete`.
+
+## Deploy via CI (GitHub Actions)
+
+`.github/workflows/proxmox-director.yml` deploys/updates/deletes the director on
+the self-hosted **`proxmox-cpi`** runner (the same one the CPI repo uses — it must
+be able to reach the Proxmox API and the director IP, and be visible to this
+repo). `state.json` + `creds.yml` are persisted to **S3-compatible object storage**
+(`proxmox/ci-deploy.sh`), so the director survives across runs. The state upload
+runs even if `create-env` fails partway, so a half-created VM is never orphaned.
+
+**Triggers:** manual (`workflow_dispatch`, with a `deploy`/`delete` choice) and
+automatically on push to `master` touching `proxmox/**` or `bosh.yml`.
+
+**Required repository secrets** (Settings → Secrets and variables → Actions):
+
+| Secret | Example |
+|---|---|
+| `PROXMOX_API_URL` | `https://pve.lan:8006` |
+| `PROXMOX_API_TOKEN` | `bosh@pve!cpi=xxxx...` |
+| `PROXMOX_NODE` | `pve1` |
+| `PROXMOX_VM_STORAGE` | `local-lvm` |
+| `PROXMOX_IMPORT_STORAGE` | `local` |
+| `PROXMOX_BRIDGE` | `vmbr0` |
+| `DIRECTOR_INTERNAL_CIDR` | `10.0.0.0/24` |
+| `DIRECTOR_INTERNAL_GW` | `10.0.0.1` |
+| `DIRECTOR_INTERNAL_IP` | `10.0.0.6` |
+| `STATE_S3_BUCKET` | `bosh-director-state` (private, SSE-enabled) |
+| `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` | bucket credentials |
+
+Optional: `PROXMOX_INSECURE_SKIP_VERIFY` (default `true`), `DIRECTOR_NAME`,
+`STATE_S3_PREFIX`, `AWS_DEFAULT_REGION`, and `AWS_S3_ENDPOINT` (set for MinIO /
+non-AWS S3).
+
+> **creds.yml holds the director admin password + CA + all internal passwords.**
+> Use a **private** bucket; uploads request SSE-S3. For MinIO, enable bucket
+> encryption and TLS on `AWS_S3_ENDPOINT`.
+
+## Using a published CPI release
+
+Once you cut a GitHub release of the CPI, skip the source build:
+
+```bash
+bosh create-env bosh.yml \
+  -o proxmox/cpi.yml \
+  -o proxmox/use-published-release.yml \
+  -o jumpbox-user.yml \
+  --state=proxmox/state.json --vars-store=proxmox/creds.yml \
+  -l proxmox/vars.yml \
+  -v proxmox_cpi_version=<X.Y.Z> \
+  -v proxmox_cpi_sha1=<sha1>
+```
+
+## cloud_properties reference
+
+See the [CPI README](https://github.com/hjaffan/bosh-proxmox-cpi#cloud_properties-reference)
+for all `vm_types`, `disk_types`, and `networks` cloud properties.

--- a/proxmox/ci-deploy.sh
+++ b/proxmox/ci-deploy.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# CI entrypoint: deploy / update / delete a BOSH director on Proxmox VE, with
+# state.json + creds.yml persisted in S3-compatible object storage (S3/MinIO)
+# so the director survives across CI runs.
+#
+# Unlike proxmox/deploy.sh (local, reads proxmox/vars.yml), this reads all
+# configuration from environment variables (CI secrets) and syncs state to a
+# bucket. The state upload runs on EXIT even when create-env fails partway, so a
+# half-created director VM recorded in state.json is never orphaned.
+#
+# Required env:
+#   PROXMOX_API_URL PROXMOX_API_TOKEN PROXMOX_NODE
+#   PROXMOX_VM_STORAGE PROXMOX_IMPORT_STORAGE
+#   DIRECTOR_INTERNAL_CIDR DIRECTOR_INTERNAL_GW DIRECTOR_INTERNAL_IP
+#   STATE_S3_BUCKET            e.g. bosh-director-state
+#   AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
+# Optional env:
+#   ACTION=deploy|delete       (default deploy)
+#   DIRECTOR_NAME              (default bosh-proxmox)
+#   PROXMOX_BRIDGE            (default vmbr0)
+#   PROXMOX_INSECURE_SKIP_VERIFY (default true)
+#   STEMCELL_URL              (default jammy openstack-kvm)
+#   STATE_S3_PREFIX           key prefix in the bucket (default director)
+#   AWS_DEFAULT_REGION        (default us-east-1)
+#   AWS_S3_ENDPOINT           set for MinIO / non-AWS, e.g. https://minio.lan:9000
+#   PROXMOX_CPI_DIR           CPI checkout to build (default ./bosh-proxmox-cpi)
+#   UPLOAD_CLOUD_CONFIG=true  after deploy, apply proxmox/cloud-config.yml
+#   UPLOAD_STEMCELL=true      after deploy, upload STEMCELL_URL to the director
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$root"
+
+# --- required config ----------------------------------------------------------
+req() { [ -n "${!1:-}" ] || { echo "FATAL: missing required env var $1" >&2; exit 2; }; }
+for v in PROXMOX_API_URL PROXMOX_API_TOKEN PROXMOX_NODE PROXMOX_VM_STORAGE \
+         PROXMOX_IMPORT_STORAGE DIRECTOR_INTERNAL_CIDR DIRECTOR_INTERNAL_GW \
+         DIRECTOR_INTERNAL_IP STATE_S3_BUCKET AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY; do
+  req "$v"
+done
+
+ACTION="${ACTION:-deploy}"
+DIRECTOR_NAME="${DIRECTOR_NAME:-bosh-proxmox}"
+BRIDGE="${PROXMOX_BRIDGE:-vmbr0}"
+INSECURE="${PROXMOX_INSECURE_SKIP_VERIFY:-true}"
+STEMCELL_URL="${STEMCELL_URL:-https://bosh.io/d/stemcells/bosh-openstack-kvm-ubuntu-jammy-go_agent}"
+STATE_S3_PREFIX="${STATE_S3_PREFIX:-director}"
+export AWS_DEFAULT_REGION="${AWS_DEFAULT_REGION:-us-east-1}"
+cpi_dir="$(cd "${PROXMOX_CPI_DIR:-$root/bosh-proxmox-cpi}" && pwd)"
+
+# aws CLI with optional custom endpoint (MinIO). SSE-S3 on upload; rely on a
+# private, encrypted bucket for creds.yml at-rest protection.
+aws_s3() { aws ${AWS_S3_ENDPOINT:+--endpoint-url "$AWS_S3_ENDPOINT"} s3 "$@"; }
+s3_uri="s3://$STATE_S3_BUCKET/$STATE_S3_PREFIX"
+
+state="$root/state.json"
+creds="$root/creds.yml"
+
+# --- BOSH CLI (installed by the workflow; Homebrew names it bosh-cli) ---------
+if command -v bosh >/dev/null 2>&1; then bosh=bosh
+elif command -v bosh-cli >/dev/null 2>&1; then bosh=bosh-cli
+else echo "FATAL: bosh CLI not found on runner" >&2; exit 2; fi
+
+# --- pull existing state from the bucket (first deploy has none) ---------------
+echo "== pulling state from $s3_uri =="
+aws_s3 cp "$s3_uri/state.json" "$state" 2>/dev/null || echo "  no existing state.json (first deploy)"
+aws_s3 cp "$s3_uri/creds.yml"  "$creds" 2>/dev/null || echo "  no existing creds.yml (first deploy)"
+
+# --- always push state back, even on partial failure --------------------------
+push_state() {
+  echo "== pushing state back to $s3_uri =="
+  [ -f "$state" ] && aws_s3 cp "$state" "$s3_uri/state.json" --sse AES256 || true
+  # creds.yml is deleted by a successful delete-env; only push when present
+  [ -f "$creds" ] && aws_s3 cp "$creds" "$s3_uri/creds.yml" --sse AES256 || true
+  # after a successful delete, clear the remote objects so the next deploy is clean
+  if [ "$ACTION" = delete ] && [ ! -f "$state" ]; then
+    aws_s3 rm "$s3_uri/state.json" 2>/dev/null || true
+    aws_s3 rm "$s3_uri/creds.yml"  2>/dev/null || true
+  fi
+}
+trap push_state EXIT
+
+# --- vendor the golang package into the CPI checkout (one-time per checkout) ---
+if [ ! -d "$cpi_dir/packages/golang-1-linux" ]; then
+  echo "== vendoring golang package into CPI at $cpi_dir =="
+  ( cd "$cpi_dir" && ./scripts/create-release.sh >/dev/null )
+fi
+
+common_args=(
+  bosh.yml
+  -o proxmox/cpi.yml
+  -o jumpbox-user.yml
+  --state="$state" --vars-store="$creds"
+  -v director_name="$DIRECTOR_NAME"
+  -v internal_cidr="$DIRECTOR_INTERNAL_CIDR"
+  -v internal_gw="$DIRECTOR_INTERNAL_GW"
+  -v internal_ip="$DIRECTOR_INTERNAL_IP"
+  -v proxmox_cpi_release="file://$cpi_dir"
+  -v proxmox_api_url="$PROXMOX_API_URL"
+  -v proxmox_api_token="$PROXMOX_API_TOKEN"
+  -v proxmox_node="$PROXMOX_NODE"
+  -v proxmox_vm_storage="$PROXMOX_VM_STORAGE"
+  -v proxmox_import_storage="$PROXMOX_IMPORT_STORAGE"
+  -v proxmox_bridge="$BRIDGE"
+  -v proxmox_insecure_skip_verify="$INSECURE"
+)
+
+if [ "$ACTION" = delete ]; then
+  echo "== delete-env: tearing down the director =="
+  "$bosh" delete-env "${common_args[@]}"
+  echo "DIRECTOR DELETED"
+  exit 0
+fi
+
+echo "== create-env: bootstrapping/updating the director =="
+"$bosh" create-env "${common_args[@]}"
+
+# --- verify + optional post-deploy wiring -------------------------------------
+export BOSH_ENVIRONMENT="$DIRECTOR_INTERNAL_IP"
+export BOSH_CLIENT=admin
+BOSH_CLIENT_SECRET="$("$bosh" int "$creds" --path /admin_password)"; export BOSH_CLIENT_SECRET
+BOSH_CA_CERT="$("$bosh" int "$creds" --path /director_ssl/ca)"; export BOSH_CA_CERT
+
+echo "== verifying the director responds =="
+"$bosh" -e "$DIRECTOR_INTERNAL_IP" env
+
+if [ "${UPLOAD_CLOUD_CONFIG:-}" = true ]; then
+  echo "== applying cloud-config =="
+  "$bosh" -n update-cloud-config proxmox/cloud-config.yml \
+    -v internal_cidr="$DIRECTOR_INTERNAL_CIDR" \
+    -v internal_gw="$DIRECTOR_INTERNAL_GW" \
+    -v proxmox_bridge="$BRIDGE"
+fi
+
+if [ "${UPLOAD_STEMCELL:-}" = true ]; then
+  echo "== uploading stemcell =="
+  "$bosh" -n upload-stemcell "$STEMCELL_URL"
+fi
+
+echo
+echo "============================================================"
+echo "DIRECTOR DEPLOYED — $DIRECTOR_INTERNAL_IP ($DIRECTOR_NAME)"
+echo "============================================================"

--- a/proxmox/cloud-config.yml
+++ b/proxmox/cloud-config.yml
@@ -1,0 +1,67 @@
+# Cloud config for a Proxmox VE installation. Vendored into this fork from
+# hjaffan/bosh-proxmox-cpi (manifests/cloud-config.yml). Adjust CIDRs, the
+# bridge, and storage names to match your environment, then apply it once the
+# director is up:
+#
+#   bosh -e proxmox update-cloud-config proxmox/cloud-config.yml -l proxmox/vars.yml
+---
+azs:
+- name: z1
+  # With a multi-node cluster, set a different node per AZ:
+  # cloud_properties:
+  #   node: pve1
+
+vm_types:
+- name: default
+  cloud_properties:
+    cpu: 2
+    ram: 4096   # MiB
+    disk: 16384 # MiB ephemeral disk (scsi1)
+- name: small
+  cloud_properties:
+    cpu: 1
+    ram: 2048
+    disk: 8192
+- name: large
+  cloud_properties:
+    cpu: 4
+    ram: 8192
+    disk: 65536
+    # cpu_type: host          # override the QEMU CPU model
+    # root_disk_size: 10240   # grow the stemcell root disk (MiB)
+    # vm_storage: fast-nvme   # per-type storage override
+
+vm_extensions:
+- name: 50GB_ephemeral_disk
+  cloud_properties:
+    disk: 51200
+
+disk_types:
+- name: default
+  disk_size: 10240 # MiB
+- name: large
+  disk_size: 102400
+  # cloud_properties:
+  #   storage: slow-hdd      # per-disk-type storage override
+
+networks:
+- name: default
+  type: manual
+  subnets:
+  - range: ((internal_cidr))
+    gateway: ((internal_gw))
+    azs: [z1]
+    dns: [8.8.8.8, 1.1.1.1]
+    reserved:
+    - ((internal_gw))/30
+    cloud_properties:
+      bridge: ((proxmox_bridge))
+      # vlan: 30              # optional VLAN tag
+      # mtu: 9000             # optional MTU
+
+compilation:
+  workers: 3
+  reuse_compilation_vms: true
+  az: z1
+  vm_type: default
+  network: default

--- a/proxmox/cpi-release-url.yml
+++ b/proxmox/cpi-release-url.yml
@@ -1,0 +1,17 @@
+# Companion to proxmox/use-published-release.yml: override the release tarball
+# URL. use-published-release.yml defaults to the GitHub release download URL;
+# apply this AFTER it to fetch the tarball from somewhere else (e.g. a CDN /
+# blobstore mirror such as https://cdn.cf-apps.io/...).
+#
+#   bosh create-env bosh.yml \
+#     -o proxmox/cpi.yml \
+#     -o proxmox/use-published-release.yml \
+#     -o proxmox/cpi-release-url.yml \
+#     -v proxmox_cpi_version=1.0.0 \
+#     -v proxmox_cpi_sha1=<sha1> \
+#     -v proxmox_cpi_url=https://cdn.cf-apps.io/bosh-proxmox-cpi-1.0.0.tgz \
+#     ...
+---
+- type: replace
+  path: /releases/name=bosh-proxmox-cpi/url
+  value: ((proxmox_cpi_url))

--- a/proxmox/cpi.yml
+++ b/proxmox/cpi.yml
@@ -1,0 +1,68 @@
+# Ops file to deploy the BOSH director on Proxmox VE using the Proxmox CPI.
+# Vendored into this fork from hjaffan/bosh-proxmox-cpi (manifests/cpi.yml).
+#
+# Layer it onto the vanilla bosh.yml in this repo. See proxmox/deploy.sh for a
+# ready-to-run wrapper, or invoke create-env directly:
+#
+#   bosh create-env bosh.yml \
+#     -o proxmox/cpi.yml \
+#     -o jumpbox-user.yml \
+#     --state=proxmox/state.json --vars-store=proxmox/creds.yml \
+#     -l proxmox/vars.yml \
+#     -v proxmox_cpi_release=file:///abs/path/to/bosh-proxmox-cpi
+#
+# `version: create` builds the CPI release from that checkout; run the CPI's
+# scripts/create-release.sh once first so the golang package is vendored
+# (proxmox/deploy.sh does this automatically). To use a published tarball
+# instead, also apply proxmox/use-published-release.yml.
+---
+- type: replace
+  path: /releases/-
+  value:
+    name: bosh-proxmox-cpi
+    version: create
+    url: ((proxmox_cpi_release))
+
+- type: replace
+  path: /resource_pools/name=vms/stemcell?
+  value:
+    url: https://bosh.io/d/stemcells/bosh-openstack-kvm-ubuntu-jammy-go_agent
+
+- type: replace
+  path: /resource_pools/name=vms/cloud_properties?
+  value:
+    cpu: 2
+    ram: 4096
+    disk: 32768
+
+- type: replace
+  path: /networks/name=default/subnets/0/cloud_properties?
+  value:
+    bridge: ((proxmox_bridge))
+
+- type: replace
+  path: /instance_groups/name=bosh/jobs/-
+  value:
+    name: proxmox_cpi
+    release: bosh-proxmox-cpi
+
+- type: replace
+  path: /instance_groups/name=bosh/properties/proxmox?
+  value: &proxmox_properties
+    api_url: ((proxmox_api_url))
+    api_token: ((proxmox_api_token))
+    insecure_skip_verify: ((proxmox_insecure_skip_verify))
+    node: ((proxmox_node))
+    vm_storage: ((proxmox_vm_storage))
+    import_storage: ((proxmox_import_storage))
+    default_bridge: ((proxmox_bridge))
+
+- type: replace
+  path: /cloud_provider/template?
+  value:
+    name: proxmox_cpi
+    release: bosh-proxmox-cpi
+
+- type: replace
+  path: /cloud_provider/properties/proxmox?
+  value: *proxmox_properties

--- a/proxmox/deploy.sh
+++ b/proxmox/deploy.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Deploy / update / delete a BOSH director on Proxmox VE from this fork.
+#
+# Usage:
+#   proxmox/deploy.sh [deploy|delete|cloud-config|env]
+#     deploy        (default) bosh create-env — bootstrap or update the director
+#     delete        bosh delete-env — tear the director down
+#     cloud-config  upload proxmox/cloud-config.yml to the running director
+#     env           print the BOSH_* env vars to talk to the director (eval it)
+#
+# Config:
+#   proxmox/vars.yml         your filled-in variables (copied from vars.tmpl.yml)
+#   PROXMOX_CPI_DIR=<path>   the bosh-proxmox-cpi checkout (default ../bosh-proxmox-cpi)
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+cpi_dir="${PROXMOX_CPI_DIR:-$repo_root/../bosh-proxmox-cpi}"
+vars_file="proxmox/vars.yml"
+state_file="proxmox/state.json"
+creds_file="proxmox/creds.yml"
+action="${1:-deploy}"
+
+# --- Locate the BOSH CLI (Homebrew ships it as "bosh-cli") ---------------------
+if command -v bosh >/dev/null 2>&1; then
+  bosh=bosh
+elif command -v bosh-cli >/dev/null 2>&1; then
+  bosh=bosh-cli
+else
+  cat >&2 <<'EOF'
+ERROR: the BOSH CLI is not installed.
+  macOS:  brew install cloudfoundry/tap/bosh-cli
+  other:  https://github.com/cloudfoundry/bosh-cli/releases
+EOF
+  exit 1
+fi
+
+# --- Ensure the vars file exists ----------------------------------------------
+if [[ ! -f "$vars_file" ]]; then
+  cp proxmox/vars.tmpl.yml "$vars_file"
+  echo "Created $vars_file from the template — fill in your Proxmox details, then re-run." >&2
+  exit 1
+fi
+
+# --- Locate the CPI checkout ---------------------------------------------------
+if [[ ! -d "$cpi_dir" ]]; then
+  echo "ERROR: bosh-proxmox-cpi checkout not found at: $cpi_dir" >&2
+  echo "       git clone git@github.com:hjaffan/bosh-proxmox-cpi.git, or set PROXMOX_CPI_DIR." >&2
+  exit 1
+fi
+cpi_dir="$(cd "$cpi_dir" && pwd)"
+
+# --- One-time vendoring of the golang package into the CPI checkout ------------
+# `version: create` in cpi.yml builds the release from the checkout, which needs
+# the golang-1-linux package vendored first. Idempotent: skip if already present.
+ensure_vendored() {
+  if [[ ! -d "$cpi_dir/packages/golang-1-linux" ]]; then
+    echo ">> Vendoring the golang package into the CPI (one-time)..."
+    ( cd "$cpi_dir" && ./scripts/create-release.sh >/dev/null )
+  fi
+}
+
+# --- BOSH_* env for talking to the running director ----------------------------
+director_env() {
+  cat <<EOF
+export BOSH_ENVIRONMENT=$($bosh int "$vars_file" --path /internal_ip)
+export BOSH_CLIENT=admin
+export BOSH_CLIENT_SECRET=$($bosh int "$creds_file" --path /admin_password)
+export BOSH_CA_CERT="$($bosh int "$creds_file" --path /director_ssl/ca)"
+EOF
+}
+
+case "$action" in
+  deploy)
+    ensure_vendored
+    echo ">> create-env: bootstrapping/updating the director (this can take a while)..."
+    "$bosh" create-env bosh.yml \
+      -o proxmox/cpi.yml \
+      -o jumpbox-user.yml \
+      --state="$state_file" \
+      --vars-store="$creds_file" \
+      -l "$vars_file" \
+      -v proxmox_cpi_release="file://$cpi_dir"
+    echo
+    echo "Done. Talk to the director with:  eval \"\$(proxmox/deploy.sh env)\""
+    ;;
+  delete)
+    ensure_vendored
+    "$bosh" delete-env bosh.yml \
+      -o proxmox/cpi.yml \
+      -o jumpbox-user.yml \
+      --state="$state_file" \
+      --vars-store="$creds_file" \
+      -l "$vars_file" \
+      -v proxmox_cpi_release="file://$cpi_dir"
+    ;;
+  cloud-config)
+    [[ -f "$creds_file" ]] || { echo "ERROR: $creds_file missing — deploy first." >&2; exit 1; }
+    eval "$(director_env)"
+    "$bosh" -n update-cloud-config proxmox/cloud-config.yml -l "$vars_file"
+    ;;
+  env)
+    [[ -f "$creds_file" ]] || { echo "ERROR: $creds_file missing — deploy first." >&2; exit 1; }
+    director_env
+    ;;
+  *)
+    echo "Unknown action: $action (use deploy|delete|cloud-config|env)" >&2
+    exit 1
+    ;;
+esac

--- a/proxmox/use-published-release.yml
+++ b/proxmox/use-published-release.yml
@@ -1,0 +1,21 @@
+# Companion ops file to proxmox/cpi.yml: use a published GitHub release tarball
+# instead of building the CPI from a local checkout. Vendored from
+# hjaffan/bosh-proxmox-cpi (manifests/use-published-release.yml).
+#
+# Apply AFTER cpi.yml and set proxmox_cpi_version / proxmox_cpi_sha1 (drop
+# proxmox_cpi_release):
+#
+#   bosh create-env bosh.yml \
+#     -o proxmox/cpi.yml \
+#     -o proxmox/use-published-release.yml \
+#     -v proxmox_cpi_version=1.0.0 \
+#     -v proxmox_cpi_sha1=<sha1 from the GitHub release notes> \
+#     ...
+---
+- type: replace
+  path: /releases/name=bosh-proxmox-cpi
+  value:
+    name: bosh-proxmox-cpi
+    version: ((proxmox_cpi_version))
+    url: https://github.com/hjaffan/bosh-proxmox-cpi/releases/download/v((proxmox_cpi_version))/bosh-proxmox-cpi-((proxmox_cpi_version)).tgz
+    sha1: ((proxmox_cpi_sha1))

--- a/proxmox/vars.tmpl.yml
+++ b/proxmox/vars.tmpl.yml
@@ -1,0 +1,23 @@
+# Deployment variables for the Proxmox BOSH director.
+#
+#   cp proxmox/vars.tmpl.yml proxmox/vars.yml   # (deploy.sh does this for you)
+#   # then fill in the values below
+#
+# proxmox/vars.yml is git-ignored because it holds your API token. Do not commit it.
+---
+# --- Director identity & networking (the director VM's static IP on your LAN) ---
+director_name: bosh-1
+internal_cidr: 10.0.0.0/24     # subnet the director lives on
+internal_gw: 10.0.0.1          # gateway for that subnet
+internal_ip: 10.0.0.6          # static IP to assign the director VM
+
+# --- Proxmox API connection ---
+proxmox_api_url: https://pve.example.com:8006
+proxmox_api_token: "bosh@pve!cpi=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+proxmox_insecure_skip_verify: true   # true if the PVE API cert is self-signed
+
+# --- Proxmox placement & storage ---
+proxmox_node: pve1             # node name to create the director on
+proxmox_vm_storage: local-lvm  # storage for VM disks (content: images)
+proxmox_import_storage: local  # storage with content: import AND iso enabled
+proxmox_bridge: vmbr0          # Linux bridge / SDN vnet for the default network


### PR DESCRIPTION
Vendor the bosh-proxmox-cpi ops files into this fork (mirroring vsphere/ et al.) so it natively supports deploying a director on Proxmox VE:

- proxmox/cpi.yml, cloud-config.yml, use-published-release.yml — ops files
- proxmox/vars.tmpl.yml — fillable deployment variables template
- proxmox/deploy.sh — local create-env/delete-env/cloud-config wrapper
- proxmox/ci-deploy.sh — CI entrypoint with S3-persisted state
- .github/workflows/proxmox-director.yml — deploy/update/delete on the self-hosted proxmox-cpi runner, state in S3/MinIO, safe against orphaned VMs on partial create-env
- .gitignore — ignore proxmox/vars.yml (holds the API token)

Note: Please create PR's against the develop branch