### PR TITLE
Add Ubuntu Resolute ops files

### DIFF
--- a/alicloud/use-resolute.yml
+++ b/alicloud/use-resolute.yml
@@ -1,0 +1,6 @@
+- name: stemcell
+  path: /resource_pools/name=vms/stemcell?
+  type: replace
+  value:
+    sha1: 87de2748162aab779ae70fff2dc40a35dc38a464
+    url: https://storage.googleapis.com/bosh-core-stemcells/0.59/bosh-stemcell-0.59-alicloud-kvm-ubuntu-resolute.tgz

--- a/aws/use-resolute.yml
+++ b/aws/use-resolute.yml
@@ -1,0 +1,6 @@
+- name: stemcell
+  path: /resource_pools/name=vms/stemcell?
+  type: replace
+  value:
+    sha1: 5b5291ec8f8126e381aa078ce13c6f513acb7ca5
+    url: https://storage.googleapis.com/bosh-aws-light-stemcells/0.59/light-bosh-stemcell-0.59-aws-xen-hvm-ubuntu-resolute.tgz

--- a/azure/use-resolute.yml
+++ b/azure/use-resolute.yml
@@ -1,0 +1,6 @@
+- name: stemcell
+  path: /resource_pools/name=vms/stemcell?
+  type: replace
+  value:
+    sha1: 665665be37d4a81e69c34c7506d1f2f616554794
+    url: https://storage.googleapis.com/bosh-core-stemcells/0.59/bosh-stemcell-0.59-azure-hyperv-ubuntu-resolute.tgz

--- a/docker/use-resolute.yml
+++ b/docker/use-resolute.yml
@@ -1,0 +1,6 @@
+- name: stemcell
+  path: /resource_pools/name=vms/stemcell?
+  type: replace
+  value:
+    sha1: c8590e55a59b6b8fe0664aad526c100ef1241d11
+    url: https://storage.googleapis.com/bosh-core-stemcells/0.59/bosh-stemcell-0.59-warden-boshlite-ubuntu-resolute.tgz

--- a/gcp/use-resolute.yml
+++ b/gcp/use-resolute.yml
@@ -1,0 +1,6 @@
+- name: stemcell
+  path: /resource_pools/name=vms/stemcell?
+  type: replace
+  value:
+    sha1: 06ead8ab4f0792f76df8cbb8c9efef9eff30c5c8
+    url: https://storage.googleapis.com/bosh-gce-light-stemcells/0.59/light-bosh-stemcell-0.59-google-kvm-ubuntu-resolute.tgz

--- a/misc/use-compiled-resolute-releases.yml
+++ b/misc/use-compiled-resolute-releases.yml
@@ -1,0 +1,64 @@
+- path: /releases/name=bosh?
+  release: bosh
+  type: replace
+  value:
+    name: bosh
+    sha1: 91a350d377e9185fbc950a1168073eb1e3207eae
+    url: https://bosh.io/d/github.com/cloudfoundry/bosh?v=283.1.3
+    version: 283.1.3
+- path: /releases/name=bpm?
+  release: bpm
+  type: replace
+  value:
+    name: bpm
+    sha1: 455fcdb91a9e0c559acbc09354a959bf226a0e34
+    url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.4.36
+    version: 1.4.36
+- path: /releases/name=backup-and-restore-sdk?
+  release: backup-and-restore-sdk
+  type: replace
+  value:
+    name: backup-and-restore-sdk
+    sha1: 3959e2eaf954003cbcb843ed36bf6d536f0e00b4
+    url: https://bosh.io/d/github.com/cloudfoundry-incubator/backup-and-restore-sdk-release?v=1.19.61
+    version: 1.19.61
+- path: /releases/name=credhub?
+  release: credhub
+  type: replace
+  value:
+    name: credhub
+    sha1: bf9569a8c698c29e5afab7454a4e8d54122bcf2f
+    url: https://bosh.io/d/github.com/pivotal-cf/credhub-release?v=2.15.17
+    version: 2.15.17
+- path: /releases/name=uaa?
+  release: uaa
+  type: replace
+  value:
+    name: uaa
+    sha1: 88381cc8f7e0a2972c9c40aa511f968b5d7c72f7
+    url: https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=79.5.0
+    version: 79.5.0
+- path: /releases/name=garden-runc?
+  release: garden-runc
+  type: replace
+  value:
+    name: garden-runc
+    sha1: 0db72e203c4418e9b46cf8f987ca383da6a8888b
+    url: https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=1.93.0
+    version: 1.93.0
+- path: /releases/name=bosh-warden-cpi?
+  release: bosh-warden-cpi
+  type: replace
+  value:
+    name: bosh-warden-cpi
+    sha1: f819bbc22b631c6d2c3e80389c2fef39d8440400
+    url: https://bosh.io/d/github.com/cloudfoundry/bosh-warden-cpi-release?v=45.2.4
+    version: 45.2.4
+- path: /releases/name=bosh-docker-cpi?
+  release: bosh-docker-cpi
+  type: replace
+  value:
+    name: bosh-docker-cpi
+    sha1: 88b200bce08fafe6dc7bf68f338f62d3c9d913aa
+    url: https://bosh.io/d/github.com/cloudfoundry/bosh-docker-cpi-release?v=0.2.17
+    version: 0.2.17

--- a/openstack/use-resolute-raw.yml
+++ b/openstack/use-resolute-raw.yml
@@ -1,0 +1,6 @@
+- name: stemcell
+  path: /resource_pools/name=vms/stemcell?
+  type: replace
+  value:
+    sha1: d6650a514c3444653fde63c4f1b27b7c88c53396
+    url: https://storage.googleapis.com/bosh-core-stemcells/0.59/bosh-stemcell-0.59-openstack-kvm-ubuntu-resolute-raw.tgz

--- a/openstack/use-resolute.yml
+++ b/openstack/use-resolute.yml
@@ -1,0 +1,6 @@
+- name: stemcell
+  path: /resource_pools/name=vms/stemcell?
+  type: replace
+  value:
+    sha1: 98dfcaf5ce811ea0a9972ddd12859e61785dd2ff
+    url: https://storage.googleapis.com/bosh-core-stemcells/0.59/bosh-stemcell-0.59-openstack-kvm-ubuntu-resolute.tgz

--- a/runtime-configs/dns.yml
+++ b/runtime-configs/dns.yml
@@ -26,6 +26,7 @@ addons:
 - include:
     stemcell:
     - os: ubuntu-noble
+    - os: ubuntu-resolute
   jobs:
   - name: bosh-dns
     properties:

--- a/vcloud/use-resolute.yml
+++ b/vcloud/use-resolute.yml
@@ -1,0 +1,6 @@
+- name: stemcell
+  path: /resource_pools/name=vms/stemcell?
+  type: replace
+  value:
+    sha1: 98dfcaf5ce811ea0a9972ddd12859e61785dd2ff
+    url: https://storage.googleapis.com/bosh-core-stemcells/0.59/bosh-stemcell-0.59-openstack-kvm-ubuntu-resolute.tgz

--- a/virtualbox/use-resolute.yml
+++ b/virtualbox/use-resolute.yml
@@ -1,0 +1,6 @@
+- name: stemcell
+  path: /resource_pools/name=vms/stemcell?
+  type: replace
+  value:
+    sha1: 6d653ba0ac8b65d2c02c34975641b1b819bad08f
+    url: https://storage.googleapis.com/bosh-core-stemcells/0.59/bosh-stemcell-0.59-vsphere-esxi-ubuntu-resolute.tgz

--- a/vsphere/use-resolute.yml
+++ b/vsphere/use-resolute.yml
@@ -1,0 +1,6 @@
+- name: stemcell
+  path: /resource_pools/name=vms/stemcell?
+  type: replace
+  value:
+    sha1: 6d653ba0ac8b65d2c02c34975641b1b819bad08f
+    url: https://storage.googleapis.com/bosh-core-stemcells/0.59/bosh-stemcell-0.59-vsphere-esxi-ubuntu-resolute.tgz

--- a/warden/use-resolute.yml
+++ b/warden/use-resolute.yml
@@ -1,0 +1,6 @@
+- name: stemcell
+  path: /resource_pools/name=vms/stemcell?
+  type: replace
+  value:
+    sha1: c8590e55a59b6b8fe0664aad526c100ef1241d11
+    url: https://storage.googleapis.com/bosh-core-stemcells/0.59/bosh-stemcell-0.59-warden-boshlite-ubuntu-resolute.tgz


### PR DESCRIPTION
Seed files for the upcoming pipeline jobs to update

- `<iaas>/use-resolute.yml` × 11, seeded with real 0.59 URLs/sha1s from bosh.io. Light stemcells for aws and gcp, regular elsewhere. alicloud publishes no light resolute stemcell yet, so it uses the regular tarball. warden is stemcell-only — resolute follows noble on `start_containers_with_systemd`.
- `misc/use-compiled-resolute-releases.yml`. Must be applied **last**. Seeded with source (uncompiled) releases deliberately: the compile-*-resolute jobs will replace them with compiled tarballs, and until then a source release is correct-but-uncompiled.
- `runtime-configs/dns.yml`: add `ubuntu-resolute` to the systemd addon block. Without it bosh-dns is silently skipped on resolute VMs and deploys fail later on link resolution.