### PR TITLE
feat: run credhub in BPM

### DIFF
--- a/credhub.yml
+++ b/credhub.yml
@@ -11,6 +11,8 @@
   value:
     name: credhub
     properties:
+      bpm:
+        enabled: true
       credhub:
         authentication:
           uaa:


### PR DESCRIPTION
BPM has been optional for credhub for 8 years, but it's never been turned on in bosh-deployment. Turning it on now for Resolute Raccoon.
