### PR TITLE
Move compiled resolute CPI releases into their IaaS ops files

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -807,7 +807,7 @@ jobs:
     input_mapping:
       release: compiled-release
     params:
-      FILE_TO_UPDATE: misc/use-compiled-resolute-releases.yml
+      FILE_TO_UPDATE: docker/use-resolute.yml
   - <<: *commit-and-upload-when-new-release
 
 - name: compile-garden-runc-resolute
@@ -876,7 +876,7 @@ jobs:
     input_mapping:
       release: compiled-release
     params:
-      FILE_TO_UPDATE: misc/use-compiled-resolute-releases.yml
+      FILE_TO_UPDATE: warden/use-resolute.yml
   - <<: *commit-and-upload-when-new-release
 
 ### Stemcells

--- a/docker/use-resolute.yml
+++ b/docker/use-resolute.yml
@@ -1,3 +1,11 @@
+- path: /releases/name=bosh-docker-cpi?
+  release: bosh-docker-cpi
+  type: replace
+  value:
+    name: bosh-docker-cpi
+    sha1: d612511d45df3179d7ce4ce49aecbf7bd2d819da
+    url: https://s3.amazonaws.com/bosh-compiled-release-tarballs/bosh-docker-cpi-0.2.17-ubuntu-resolute-0.93.tgz
+    version: 0.2.17
 - name: stemcell
   path: /resource_pools/name=vms/stemcell?
   type: replace

--- a/misc/use-compiled-resolute-releases.yml
+++ b/misc/use-compiled-resolute-releases.yml
@@ -46,19 +46,3 @@
     sha1: 0db72e203c4418e9b46cf8f987ca383da6a8888b
     url: https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=1.93.0
     version: 1.93.0
-- path: /releases/name=bosh-warden-cpi?
-  release: bosh-warden-cpi
-  type: replace
-  value:
-    name: bosh-warden-cpi
-    sha1: 1e85d2d300f45f04a534f3ef501e36c262244be4
-    url: https://s3.amazonaws.com/bosh-compiled-release-tarballs/bosh-warden-cpi-45.2.4-ubuntu-resolute-0.93.tgz
-    version: 45.2.4
-- path: /releases/name=bosh-docker-cpi?
-  release: bosh-docker-cpi
-  type: replace
-  value:
-    name: bosh-docker-cpi
-    sha1: d612511d45df3179d7ce4ce49aecbf7bd2d819da
-    url: https://s3.amazonaws.com/bosh-compiled-release-tarballs/bosh-docker-cpi-0.2.17-ubuntu-resolute-0.93.tgz
-    version: 0.2.17

--- a/warden/use-resolute.yml
+++ b/warden/use-resolute.yml
@@ -1,3 +1,11 @@
+- path: /releases/name=bosh-warden-cpi?
+  release: bosh-warden-cpi
+  type: replace
+  value:
+    name: bosh-warden-cpi
+    sha1: 1e85d2d300f45f04a534f3ef501e36c262244be4
+    url: https://s3.amazonaws.com/bosh-compiled-release-tarballs/bosh-warden-cpi-45.2.4-ubuntu-resolute-0.93.tgz
+    version: 45.2.4
 - name: stemcell
   path: /resource_pools/name=vms/stemcell?
   type: replace


### PR DESCRIPTION
The bosh-warden-cpi and bosh-docker-cpi entries in misc/use-compiled-resolute-releases.yml were injected into every manifest that file touched: a GCP director came out carrying both, referenced by no job.

Move each into warden/use-resolute.yml and docker/use-resolute.yml, and repoint FILE_TO_UPDATE on the two compile jobs. Both CPIs still resolve to their compiled tarballs. The other eight IaaS CPIs have no resolute compile job and are unaffected.