### PR TITLE
ci: fix cpi container images

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1794,11 +1794,13 @@ resources:
 - name: bosh-docker-cpi-image
   type: registry-image
   source:
+    tag: main
     repository: ghcr.io/cloudfoundry/bosh/docker-cpi
 
 - name: bosh-warden-cpi-image
   type: registry-image
   source:
+    tag: main
     repository: ghcr.io/cloudfoundry/bosh/warden-cpi
 
 resource_types:


### PR DESCRIPTION
The bosh pipleine doesn't tag images with latest, it tags them with the branch name. Switching to main so we pick up current images.