### PR TITLE
replace openstack_cpi with openstack_cpi_golang

### DIFF
--- a/openstack/cpi-secondary.yml
+++ b/openstack/cpi-secondary.yml
@@ -10,7 +10,7 @@
 - type: replace
   path: /instance_groups/name=bosh/jobs/-
   value:
-    name: openstack_cpi
+    name: openstack_cpi_golang
     release: bosh-openstack-cpi
 
 # unused values should be overwritten via Director's cpi config

--- a/openstack/cpi.yml
+++ b/openstack/cpi.yml
@@ -24,15 +24,15 @@
 - path: /instance_groups/name=bosh/jobs/-
   type: replace
   value:
-    name: openstack_cpi
+    name: openstack_cpi_golang
     release: bosh-openstack-cpi
 - path: /instance_groups/name=bosh/properties/director/cpi_job?
   type: replace
-  value: openstack_cpi
+  value: openstack_cpi_golang
 - path: /cloud_provider/template?
   type: replace
   value:
-    name: openstack_cpi
+    name: openstack_cpi_golang
     release: bosh-openstack-cpi
 - path: /instance_groups/name=bosh/properties/openstack?
   type: replace


### PR DESCRIPTION
Since we are moving openstack-cpi from ruby to Golang, the cpi.yml should also be updated.