### PR TITLE
Update Azure default VM sizes to Dsv5

### DIFF
--- a/azure/cloud-config.yml
+++ b/azure/cloud-config.yml
@@ -6,10 +6,10 @@ azs:
 vm_types:
 - name: default
   cloud_properties:
-    instance_type: Standard_D1_v2
+    instance_type: Standard_D2s_v5
 - name: large
   cloud_properties:
-    instance_type: Standard_D3_v2
+    instance_type: Standard_D4s_v5
 
 disk_types:
 - name: default


### PR DESCRIPTION
Azure Dv2 sizes are scheduled for [retirement on May 1, 2028](https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/lifecycle/retirement/d-ds-dv2-dsv2-ls-series-migration-guide#q-which-sizes-are-being-retired). Avoid directing new BOSH deployments onto hardware that will require migration by updating the default and large VM types to Dsv5.

Use Dsv5 rather than Dsv6 or newer, because it supports both Gen1 and Gen2 stemcells. For, example Dsv6 is Gen2-only and would break the supported Azure Jammy configuration.