### PR TITLE
Change AWS S3 URLs from format s3.amazonaws.com/<bucketname>  to  <bu…

### DIFF
--- a/bbr.yml
+++ b/bbr.yml
@@ -4,7 +4,7 @@
   value:
     name: backup-and-restore-sdk
     sha1: 94e3f6c0f34bc4080052f56bbf87718f379e427f
-    url: https://s3.amazonaws.com/bosh-compiled-release-tarballs/backup-and-restore-sdk-1.20.3-ubuntu-noble-1.562.tgz
+    url: https://bosh-compiled-release-tarballs.s3.amazonaws.com/backup-and-restore-sdk-1.20.3-ubuntu-noble-1.562.tgz
     version: 1.20.3
 - path: /instance_groups/name=bosh/jobs/-
   type: replace

--- a/bosh-lite-docker.yml
+++ b/bosh-lite-docker.yml
@@ -4,7 +4,7 @@
   value:
     name: bosh-docker-cpi
     sha1: d3bc0b61f38640d38f631bf10638b19d9a5fc83c
-    url: https://s3.amazonaws.com/bosh-compiled-release-tarballs/bosh-docker-cpi-0.2.20-ubuntu-noble-1.560.tgz
+    url: https://bosh-compiled-release-tarballs.s3.amazonaws.com/bosh-docker-cpi-0.2.20-ubuntu-noble-1.560.tgz
     version: 0.2.20
 - path: /releases/-
   type: replace

--- a/bosh-lite.yml
+++ b/bosh-lite.yml
@@ -4,7 +4,7 @@
   value:
     name: garden-runc
     sha1: 93eed7d3b31a9560bf5ee7357161fd2efebd5092
-    url: https://s3.amazonaws.com/bosh-compiled-release-tarballs/garden-runc-1.96.0-ubuntu-noble-1.562.tgz
+    url: https://bosh-compiled-release-tarballs.s3.amazonaws.com/garden-runc-1.96.0-ubuntu-noble-1.562.tgz
     version: 1.96.0
 - path: /releases/-
   release: bosh-warden-cpi
@@ -12,7 +12,7 @@
   value:
     name: bosh-warden-cpi
     sha1: fe2a502817f42430d7090d6a263e4c260a69a9b8
-    url: https://s3.amazonaws.com/bosh-compiled-release-tarballs/bosh-warden-cpi-45.2.7-ubuntu-noble-1.562.tgz
+    url: https://bosh-compiled-release-tarballs.s3.amazonaws.com/bosh-warden-cpi-45.2.7-ubuntu-noble-1.562.tgz
     version: 45.2.7
 - path: /instance_groups/name=bosh/jobs/-
   type: replace

--- a/bosh.yml
+++ b/bosh.yml
@@ -145,11 +145,11 @@ networks:
 releases:
 - name: bosh
   sha1: aea8b3ff96f5f8f4352c7438c18b23e96a2d7e99
-  url: https://s3.amazonaws.com/bosh-compiled-release-tarballs/bosh-283.1.8-ubuntu-noble-1.562.tgz
+  url: https://bosh-compiled-release-tarballs.s3.amazonaws.com/bosh-283.1.8-ubuntu-noble-1.562.tgz
   version: 283.1.8
 - name: bpm
   sha1: 5dbc7e2b20c08836df7c44d08d25b008caf03b9a
-  url: https://s3.amazonaws.com/bosh-compiled-release-tarballs/bpm-1.4.39-ubuntu-noble-1.562.tgz
+  url: https://bosh-compiled-release-tarballs.s3.amazonaws.com/bpm-1.4.39-ubuntu-noble-1.562.tgz
   version: 1.4.39
 resource_pools:
 - env:

--- a/ci/tasks/update-release.sh
+++ b/ci/tasks/update-release.sh
@@ -11,7 +11,7 @@ git clone bosh-deployment bosh-deployment-output
 
 if [[ `grep compiled_packages release.MF` ]]; then
   TARBALL_NAME="$(basename release/*.tgz)"
-  URL="https://s3.amazonaws.com/bosh-compiled-release-tarballs/${TARBALL_NAME}"
+  URL="https://bosh-compiled-release-tarballs.s3.amazonaws.com/${TARBALL_NAME}"
 else
   URL="https://bosh.io/d/github.com/${BOSH_IO_RELEASE}?v=${VERSION}"
   test_bosh_io_release_exists $URL

--- a/credhub.yml
+++ b/credhub.yml
@@ -4,7 +4,7 @@
   value:
     name: credhub
     sha1: a88f03202308e1ff5fbb949d38395983a0a8f173
-    url: https://s3.amazonaws.com/bosh-compiled-release-tarballs/credhub-2.15.21-ubuntu-noble-1.562.tgz
+    url: https://bosh-compiled-release-tarballs.s3.amazonaws.com/credhub-2.15.21-ubuntu-noble-1.562.tgz
     version: 2.15.21
 - path: /instance_groups/name=bosh/jobs/-
   type: replace

--- a/docker/use-resolute.yml
+++ b/docker/use-resolute.yml
@@ -4,7 +4,7 @@
   value:
     name: bosh-docker-cpi
     sha1: a70b55c903b45a3e9c0bc4fd2cc64ffbd84e2809
-    url: https://s3.amazonaws.com/bosh-compiled-release-tarballs/bosh-docker-cpi-0.2.20-ubuntu-resolute-0.93.tgz
+    url: https://bosh-compiled-release-tarballs.s3.amazonaws.com/bosh-docker-cpi-0.2.20-ubuntu-resolute-0.93.tgz
     version: 0.2.20
 - name: stemcell
   path: /resource_pools/name=vms/stemcell?

--- a/misc/use-compiled-resolute-releases.yml
+++ b/misc/use-compiled-resolute-releases.yml
@@ -4,7 +4,7 @@
   value:
     name: bosh
     sha1: 2891764ac0d129d6252703a07e2ced966de8d7d1
-    url: https://s3.amazonaws.com/bosh-compiled-release-tarballs/bosh-283.1.8-ubuntu-resolute-0.93.tgz
+    url: https://bosh-compiled-release-tarballs.s3.amazonaws.com/bosh-283.1.8-ubuntu-resolute-0.93.tgz
     version: 283.1.8
 - path: /releases/name=bpm?
   release: bpm
@@ -12,7 +12,7 @@
   value:
     name: bpm
     sha1: 9ccc5e94a6cee7192edca5d016fe1ef2fbac212d
-    url: https://s3.amazonaws.com/bosh-compiled-release-tarballs/bpm-1.4.39-ubuntu-resolute-0.93.tgz
+    url: https://bosh-compiled-release-tarballs.s3.amazonaws.com/bpm-1.4.39-ubuntu-resolute-0.93.tgz
     version: 1.4.39
 - path: /releases/name=backup-and-restore-sdk?
   release: backup-and-restore-sdk
@@ -20,7 +20,7 @@
   value:
     name: backup-and-restore-sdk
     sha1: daf090b5c6b7801d475b921912f5a727f5697dcf
-    url: https://s3.amazonaws.com/bosh-compiled-release-tarballs/backup-and-restore-sdk-1.20.3-ubuntu-resolute-0.93.tgz
+    url: https://bosh-compiled-release-tarballs.s3.amazonaws.com/backup-and-restore-sdk-1.20.3-ubuntu-resolute-0.93.tgz
     version: 1.20.3
 - path: /releases/name=credhub?
   release: credhub
@@ -28,7 +28,7 @@
   value:
     name: credhub
     sha1: 8603a8b31f06392a6f22a0b5800875b36c46dbae
-    url: https://s3.amazonaws.com/bosh-compiled-release-tarballs/credhub-2.15.21-ubuntu-resolute-0.93.tgz
+    url: https://bosh-compiled-release-tarballs.s3.amazonaws.com/credhub-2.15.21-ubuntu-resolute-0.93.tgz
     version: 2.15.21
 - path: /releases/name=uaa?
   release: uaa
@@ -36,7 +36,7 @@
   value:
     name: uaa
     sha1: 4aac2d52761fbe5dccfa133118411608cb9ad88f
-    url: https://s3.amazonaws.com/bosh-compiled-release-tarballs/uaa-79.7.0-ubuntu-resolute-0.93.tgz
+    url: https://bosh-compiled-release-tarballs.s3.amazonaws.com/uaa-79.7.0-ubuntu-resolute-0.93.tgz
     version: 79.7.0
 - path: /releases/name=garden-runc?
   release: garden-runc
@@ -44,5 +44,5 @@
   value:
     name: garden-runc
     sha1: bf65726f1f7e9281de9998e417078f9aab066b06
-    url: https://s3.amazonaws.com/bosh-compiled-release-tarballs/garden-runc-1.96.0-ubuntu-resolute-0.93.tgz
+    url: https://bosh-compiled-release-tarballs.s3.amazonaws.com/garden-runc-1.96.0-ubuntu-resolute-0.93.tgz
     version: 1.96.0

--- a/softlayer/cpi-dynamic.yml
+++ b/softlayer/cpi-dynamic.yml
@@ -10,7 +10,7 @@
 - type: replace
   path: /resource_pools/name=vms/stemcell?
   value:
-    url: https://s3.amazonaws.com/bosh-softlayer-cpi-stemcells/light-bosh-stemcell-97.15-softlayer-xen-ubuntu-xenial-go_agent.tgz
+    url: https://bosh-softlayer-cpi-stemcells.s3.amazonaws.com/light-bosh-stemcell-97.15-softlayer-xen-ubuntu-xenial-go_agent.tgz
     sha1: 67c7ce1adab587d578d151ab50bc2ba1d5a1a79f
 
 - type: replace

--- a/softlayer/cpi.yml
+++ b/softlayer/cpi.yml
@@ -10,7 +10,7 @@
 - type: replace
   path: /resource_pools/name=vms/stemcell?
   value:
-    url: https://s3.amazonaws.com/bosh-softlayer-cpi-stemcells/light-bosh-stemcell-97.15-softlayer-xen-ubuntu-xenial-go_agent.tgz
+    url: https://bosh-softlayer-cpi-stemcells.s3.amazonaws.com/light-bosh-stemcell-97.15-softlayer-xen-ubuntu-xenial-go_agent.tgz
     sha1: 67c7ce1adab587d578d151ab50bc2ba1d5a1a79f
 
 - type: replace

--- a/tests/run-checks.sh
+++ b/tests/run-checks.sh
@@ -25,7 +25,7 @@ echo -e "\nCheck YAML syntax\n"
 find . -type "f" -name "*.yml" -print | tee /dev/stderr | xargs -n1 bosh interpolate > /dev/null
 
 echo -e "\nUsed compiled releases\n"
-grep -r -i s3.amazonaws.com/bosh-compiled-release-tarballs . | grep -v grep | grep -v ./.git
+grep -r -i bosh-compiled-release-tarballs.s3.amazonaws.com . | grep -v grep | grep -v ./.git
 
 echo -e "\nUsed stemcells\n"
 grep -r -i d/stemcells . | grep -v grep | grep -v ./.git

--- a/uaa.yml
+++ b/uaa.yml
@@ -4,7 +4,7 @@
   value:
     name: uaa
     sha1: 412611af9d2e43bb1bcedf5ade0c1dbb8d7c210c
-    url: https://s3.amazonaws.com/bosh-compiled-release-tarballs/uaa-79.7.0-ubuntu-noble-1.562.tgz
+    url: https://bosh-compiled-release-tarballs.s3.amazonaws.com/uaa-79.7.0-ubuntu-noble-1.562.tgz
     version: 79.7.0
 - path: /instance_groups/name=bosh/properties/director/user_management/provider
   type: replace

--- a/warden/use-resolute.yml
+++ b/warden/use-resolute.yml
@@ -4,7 +4,7 @@
   value:
     name: bosh-warden-cpi
     sha1: 26e9be0ac85655c4331827730821c3330b30da8a
-    url: https://s3.amazonaws.com/bosh-compiled-release-tarballs/bosh-warden-cpi-45.2.7-ubuntu-resolute-0.93.tgz
+    url: https://bosh-compiled-release-tarballs.s3.amazonaws.com/bosh-warden-cpi-45.2.7-ubuntu-resolute-0.93.tgz
     version: 45.2.7
 - name: stemcell
   path: /resource_pools/name=vms/stemcell?


### PR DESCRIPTION
Change AWS S3 URLs from format s3.amazonaws.com/<bucketname>  to  <bucketname>.s3.amazonaws.com

This allows for more fine-grained access control in certain firewall rules

